### PR TITLE
Move LDAS to FV_PRECISION=R4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set (DOING_GEOS5 YES)
 set (ACG_FLAGS -v)
 set (F2PYEXT .so)
 set (F2PY_SUFFIX .so)
-set (FV_PRECISION R4R8)
+set (FV_PRECISION R4)
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@cmake")
 include (esma)
@@ -43,4 +43,3 @@ include_directories(${MPI_Fortran_INCLUDE_PATH})
 # Recursively build source tree
 add_subdirectory (@env)
 add_subdirectory (src)
-


### PR DESCRIPTION
I don't think the LDAS needs to use the R4R8 workaround. Set to be R4