### PR TITLE
Add FMS as a new external

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -28,6 +28,13 @@ local_path = ./src/Shared/@MAPL
 branch = master
 protocol = git
 
+[FMS]
+required = True
+repo_url = git@github.com:GEOS-ESM/FMS.git
+local_path = ./src/Shared/@GFDL_fms
+tag = geos/orphan/v1.0.0
+protocol = git
+
 [GEOSgcm_GridComp]
 required = True
 repo_url = git@github.com:GEOS-ESM/GEOSgcm_GridComp.git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -17,7 +17,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.3
+tag = v1.0.10
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 
@@ -26,6 +26,13 @@ required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
 tag = v1.1.8
+protocol = git
+
+[FMS]
+required = True
+repo_url = git@github.com:GEOS-ESM/FMS.git
+local_path = ./src/Shared/@GFDL_fms
+tag = geos/orphan/v1.0.0
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -1,2 +1,3 @@
 /@GMAO_Shared
 /@MAPL
+/@GFDL_fms

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,2 +1,6 @@
 add_subdirectory (@MAPL)
 add_subdirectory (@GMAO_Shared)
+
+# Special case - GFDL_fms is built twice with two
+add_subdirectory (@GFDL_fms GFDL_fms_r4)
+add_subdirectory (@GFDL_fms GFDL_fms_r8)


### PR DESCRIPTION
To use GMAO_Shared 1.0.6 and higher, you need to add FMS as a new
external. This means *every* `manage_externals` `.cfg` file needs to
move up because of the change to `src/Shared/CMakeLists.txt`