### PR TITLE
Fixes #54. Updates for the FMS change in GCM

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -31,8 +31,8 @@ protocol = git
 [FMS]
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
-local_path = ./src/Shared/@GFDL_fms
-tag = geos/orphan/v1.0.0
+local_path = ./src/Shared/@FMS
+tag = geos/orphan/v1.0.2
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -1,3 +1,3 @@
 /@GMAO_Shared
 /@MAPL
-/@GFDL_fms
+/@FMS

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory (@MAPL)
 add_subdirectory (@GMAO_Shared)
 
-# Special case - GFDL_fms is built twice with two
-add_subdirectory (@GFDL_fms GFDL_fms_r4)
-add_subdirectory (@GFDL_fms GFDL_fms_r8)
+# Special case - FMS is built twice with two
+add_subdirectory (@FMS fms_r4)
+add_subdirectory (@FMS fms_r8)


### PR DESCRIPTION
This lets `develop` with `Develop.cfg` build again. It didn't last night.