### PR TITLE
fix for different nco versions

### DIFF
--- a/src/Applications/LDAS_App/lenkf.j.template
+++ b/src/Applications/LDAS_App/lenkf.j.template
@@ -442,7 +442,7 @@ EOF
           sed -i -e "s/DATAVALUES/$tstep2/g" timestamp.cdl
           ncgen -k4 -o timestamp.nc4 timestamp.cdl
           ncrcat -h $EXPID.$ThisCol.${YYYY}${MM}${DD}_* ${EXPID}.${ThisCol}.$YYYY$MM$DD.nc4
-          ncks -h -v time_stamp timestamp.nc4 -A ${EXPID}.${ThisCol}.$YYYY$MM$DD.nc4
+          ncks -4 -h -v time_stamp timestamp.nc4 -A ${EXPID}.${ThisCol}.$YYYY$MM$DD.nc4
           /bin/rm timestamp.cdl
           /bin/rm timestamp.nc4
           /bin/rm $EXPID.${ThisCol}.${YYYY}${MM}${DD}_*.nc4 
@@ -514,7 +514,7 @@ while ($inens < $NENS)
 
     set rstf = 'landpert'
     if (-f ${rstf}${ENSID}_internal_checkpoint ) then
-       ncks -O -C -x -v lat,lon -L 2 ${rstf}${ENSID}_internal_checkpoint $EXPDIR/output/$EXPDOMAIN/rs/$ENSDIR/Y${eYEAR}/M${eMON}/${EXPID}.${rstf}_internal_rst.${eYEAR}${eMON}${eDAY}_${eHour}${eMin}
+       ncks -4 -O -C -x -v lat,lon -L 2 ${rstf}${ENSID}_internal_checkpoint $EXPDIR/output/$EXPDOMAIN/rs/$ENSDIR/Y${eYEAR}/M${eMON}/${EXPID}.${rstf}_internal_rst.${eYEAR}${eMON}${eDAY}_${eHour}${eMin}
        /bin/rm -f ${rstf}${ENSID}_internal_checkpoint 
        /bin/rm -f $EXPDIR/input/restart/${rstf}${ENSID}_internal_rst
        /bin/ln -s  $EXPDIR/output/$EXPDOMAIN/rs/$ENSDIR/Y${eYEAR}/M${eMON}/${EXPID}.${rstf}_internal_rst.${eYEAR}${eMON}${eDAY}_${eHour}${eMin} $EXPDIR/input/restart/${rstf}${ENSID}_internal_rst
@@ -553,7 +553,7 @@ while ($inens < $NENS)
           set TM = `echo $ThisTime | cut -c5-6` 
           set THISDIR = $EXPDIR/output/$EXPDOMAIN/rs/$ENSDIR/Y${TY}/M${TM}/
           if (! -e $THISDIR            ) mkdir -p $THISDIR
-          ncks -O -C -x -v lat,lon -L 2 $rfile ${THISDIR}${EXPID}.landpert_internal_rst.${ThisTime}.nc4
+          ncks -4 -O -C -x -v lat,lon -L 2 $rfile ${THISDIR}${EXPID}.landpert_internal_rst.${ThisTime}.nc4
           /bin/rm -f $rfile
        end
     endif

--- a/src/Applications/LDAS_App/process_rst.csh
+++ b/src/Applications/LDAS_App/process_rst.csh
@@ -102,12 +102,12 @@ sleep 2
 
 if($LSM_CHOICE == 1) then
    if (-f irrigation_internal_rst && $RUN_IRRIG == 1) then 
-      ncks -v IRRIGFRAC,PADDYFRAC,LAIMIN,LAIMAX,CLMPT,CLMST,CLMPF,CLMSF irrigation_internal_rst -A catch_internal_rst
+      ncks -4  -v IRRIGFRAC,PADDYFRAC,LAIMIN,LAIMAX,CLMPT,CLMST,CLMPF,CLMSF irrigation_internal_rst -A catch_internal_rst
    endif
    ln -s  catch_internal_rst catch_internal_rst.$YYYYMMDD
 else
    if (-f irrigation_internal_rst && $RUN_IRRIG == 1) then 
-      ncks -v IRRIGFRAC,PADDYFRAC,LAIMIN,LAIMAX,CLMPT,CLMST,CLMPF,CLMSF irrigation_internal_rst -A catchcn_internal_rst 
+      ncks -4 -v IRRIGFRAC,PADDYFRAC,LAIMIN,LAIMAX,CLMPT,CLMST,CLMPF,CLMSF irrigation_internal_rst -A catchcn_internal_rst 
    endif
    ln -s  catchcn_internal_rst catchcn_internal_rst.$YYYYMMDD
 endif
@@ -149,7 +149,7 @@ case [1]:
         while ($j < $NUMENS)
            set ENS = `printf '%04d' $j`
            echo  bin/mk_LDASsaRestarts -b ${BCSDIR} -d ${YYYYMMDD} -e ${RESTART_ID} -k ${ENS} -l ${RESTART_short} -m ${MODEL} -s 50 -r Y -t ${TILFILE}  >> this.file
-           echo  ncks -O -h -x -v IRRIGFRAC,PADDYFRAC,LAIMIN,LAIMAX,CLMPT,CLMST,CLMPF,CLMSF ${MODEL}${ENS}_internal_rst.${YYYYMMDD} ${MODEL}${ENS}_internal_rst.${YYYYMMDD} >> this.file 
+           echo  ncks -4  -O -h -x -v IRRIGFRAC,PADDYFRAC,LAIMIN,LAIMAX,CLMPT,CLMST,CLMPF,CLMSF ${MODEL}${ENS}_internal_rst.${YYYYMMDD} ${MODEL}${ENS}_internal_rst.${YYYYMMDD} >> this.file 
            @ j++
         end
 


### PR DESCRIPTION
trivial change, but I tested it to be 0 diff anyways in a short assim test.

If the someone does have a old nco version in there path, ncks in ldas_setup will spit out the warning:
`ncks: ERROR Requested netCDF4-format output file but NCO was not built with netCDF4 support`

