### PR TITLE
revert to non-0diff changes in LandPert and Metforce

### DIFF
--- a/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
@@ -2486,15 +2486,14 @@ contains
           end select
        end do
 
-! JP: temp comment out to test 0-diff       
-!        call check_cat_progns(land_nt_local, cat_param, tcPert(:,1), tcPert(:,2), tcPert(:,4),               &
-! !          qa1,qa2,qa4, capac                       &
-!           catdefPert,                                  &
-!           rzexcPert, srfexcPert,                                  &
-!          ghtcnt1Pert,ghtcnt2Pert,ghtcnt3Pert,ghtcnt4Pert,ghtcnt5Pert,ghtcnt6Pert, &
-!          wesnn1Pert,wesnn2Pert,wesnn3Pert, &
-!          htsnnn1Pert,htsnnn2Pert,htsnnn3Pert, &
-!          sndzn1Pert, sndzn2Pert,sndzn3Pert)
+       call check_cat_progns(land_nt_local, cat_param, tcPert(:,1), tcPert(:,2), tcPert(:,4),               &
+!          qa1,qa2,qa4, capac                       &
+          catdefPert,                                  &
+          rzexcPert, srfexcPert,                                  &
+         ghtcnt1Pert,ghtcnt2Pert,ghtcnt3Pert,ghtcnt4Pert,ghtcnt5Pert,ghtcnt6Pert, &
+         wesnn1Pert,wesnn2Pert,wesnn3Pert, &
+         htsnnn1Pert,htsnnn2Pert,htsnnn3Pert, &
+         sndzn1Pert, sndzn2Pert,sndzn3Pert)
     end if
 
     call MAPL_TimerOff(MAPL, '-ApplyPert')

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/GEOS_MetforceGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/GEOS_MetforceGridComp.F90
@@ -948,6 +948,7 @@ contains
             currTime=internal%mf%TimePrv,                                       &
             INTV=internal%mf%ntrvl,                                             &
             ZTHB=internal%mf%zenav,                                             &
+            STEPSIZE=150.0,                                                     &
             rc=status                                                           &
             )
        VERIFY_(STATUS) 
@@ -980,6 +981,7 @@ contains
          INTV=ModelTimeStep,                                                    &
          ZTHB=zth,                                                              &
          currTime=ModelTimeCur,                                                 &
+         STEPSIZE=150.0,                                                        &
          rc=status                                                              &
          )
     VERIFY_(status)


### PR DESCRIPTION
Expected non-0-diff changes from check_cat_progns and zenith stepsize