### PR TITLE
Use v2.0.1 tag of ESMA_env (g5_modules that works for SLES11 and SLES12)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v2.0.0
+tag = v2.0.1
 protocol = git
 
 [ESMA_cmake]


### PR DESCRIPTION
Update Externals.cfg for new v2.0.1 tag of ESMA_env with g5_modules that works for SLES11 and SLES12