### PR TITLE
Use ESMA_env with Intel-19 compiler

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v2.0.2
+tag = v2.0.4+intel19.10
 protocol = git
 
 [ESMA_cmake]


### PR DESCRIPTION
Use ESMA_env with Intel-19 compiler (v2.0.4+intel19.10).
@weiyuan-jiang tested before with Intel-19 and found zero-diff.
Assuming that this will be ok.  Automated tests should confirm tonight.