### PR TITLE
checkpoint files are geneareted by GEOSldas 

### DIFF
--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -1180,7 +1180,7 @@ class LDASsetup:
                 valn = self.catch+ensid+'_internal_checkpoint'
                 ldasrcInp[keyn]= valn
 
-                if((self.has_ldassa_pert or self.has_geos_pert) and _perturb == 1):
+                if('-CF' not in self.rqdExeInp['GRIDNAME'] and _perturb == 1):
                     keyn = 'LANDPERT_INTERNAL_CHECKPOINT_FILE'
                     valn = 'landpert'+ensid+'_internal_checkpoint'
                     ldasrcInp[keyn]= valn

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -1180,6 +1180,8 @@ class LDASsetup:
                 valn = self.catch+ensid+'_internal_checkpoint'
                 ldasrcInp[keyn]= valn
 
+                # for lat/lon and EASE tile space, specify LANDPERT checkpoint file here (via MAPL);
+                # for cube-sphere tile space, Landpert GC will set up LANDPERT checkpoint file 
                 if('-CF' not in self.rqdExeInp['GRIDNAME'] and _perturb == 1):
                     keyn = 'LANDPERT_INTERNAL_CHECKPOINT_FILE'
                     valn = 'landpert'+ensid+'_internal_checkpoint'

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -1416,7 +1416,7 @@ contains
     integer,        dimension(numprocs)       :: N_obsl_vec, tmp_low_ind
 
     character(300)                            :: fname
-
+    integer                                   :: i
 #ifdef LDAS_MPI
 
     integer                                   :: this_species, ind_tmp, j
@@ -1559,7 +1559,10 @@ contains
 
        fname = get_io_filename( work_path, exp_id, file_tag, date_time=date_time, &
             dir_name=dir_name, ens_id=-1 )
+       i = index(fname, '/', .true.) 
 
+       if( i >0) call system('mkdir -p '//fname(1:i))
+         
        open( 10, file=fname, form='unformatted', action='write')
 
        ! write header

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -1561,7 +1561,7 @@ contains
             dir_name=dir_name, ens_id=-1 )
        i = index(fname, '/', .true.) 
 
-       if( i >0) call system('mkdir -p '//fname(1:i))
+       if( i >0) call Execute_command_line('mkdir -p '//fname(1:i))
          
        open( 10, file=fname, form='unformatted', action='write')
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_read_obs.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_read_obs.F90
@@ -524,7 +524,7 @@ contains
 
     cmd = '/bin/rm -f ' // tmpfname 
     
-    call system(trim(cmd))
+    call Execute_command_line(trim(cmd))
     
     ! identify all files within current assimilation interval
     ! (list all files within hourly intervals)
@@ -554,7 +554,7 @@ contains
        
        cmd = trim(cmd) // ' >> ' // trim(tmpfname)
        
-       call system(trim(cmd))
+       call Execute_command_line(trim(cmd))
        
        call augment_date_time( 3600, date_time_tmp )
        
@@ -566,7 +566,7 @@ contains
     
     cmd = 'wc -w ' // trim(tmpfname) // ' > ' // trim(tmpfname2)
     
-    call system(trim(cmd))
+    call Execute_command_line(trim(cmd))
     
     open(10, file=tmpfname2, form='formatted', action='read')
     
@@ -1037,7 +1037,7 @@ contains
 
     cmd = '/bin/rm -f ' // tmpfname 
     
-    call system(trim(cmd))
+    call Execute_command_line(trim(cmd))
     
     ! identify all files within current assimilation interval
     ! (list all files within hourly intervals)
@@ -1070,7 +1070,7 @@ contains
        
        cmd = trim(cmd) // ' >> ' // trim(tmpfname)
        
-       call system(trim(cmd))
+       call Execute_command_line(trim(cmd))
        
        call augment_date_time( 3600, date_time_tmp )
        
@@ -1082,7 +1082,7 @@ contains
     
     cmd = 'wc -w ' // trim(tmpfname) // ' > ' // trim(tmpfname2)
     
-    call system(trim(cmd))
+    call Execute_command_line(trim(cmd))
     
     open(10, file=tmpfname2, form='formatted', action='read')
     
@@ -1348,7 +1348,7 @@ contains
 
     cmd = '/bin/rm -f ' // tmpfname 
     
-    call system(trim(cmd))
+    call Execute_command_line(trim(cmd))
     
     ! identify all files within current assimilation interval
     ! (list all files within hourly intervals)
@@ -1379,7 +1379,7 @@ contains
 
        cmd = trim(cmd) // ' >> ' // trim(tmpfname)
        
-       call system(trim(cmd))
+       call Execute_command_line(trim(cmd))
        
        
        call augment_date_time( 3600, date_time_tmp )
@@ -1392,7 +1392,7 @@ contains
     
     cmd = 'wc -w ' // trim(tmpfname) // ' > ' // trim(tmpfname2)
     
-    call system(trim(cmd))
+    call Execute_command_line(trim(cmd))
     
     open(10, file=tmpfname2, form='formatted', action='read')
     

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
@@ -475,7 +475,7 @@ contains
 
        i=index(catch_file,'/clsm/')
        fname = catch_file(1:i)//'topo_DYN_ave_*.data'
-       call system('ls '//trim(fname) // ' >topo_DYN_ave.file')
+       call Execute_command_line('ls '//trim(fname) // ' >topo_DYN_ave.file')
        open(10,file='topo_DYN_ave.file', action='read')
        fname= ''
        read(10,'(A)') fname


### PR DESCRIPTION
This pull request addresses two things:
- Don't need the line directing the landpert checkpoint output when on cube-sphere tiles
- Create directories from within F90 executable for ObsFcstAna files.  (Facilitates extending an existing GEOSldas run without going through setup.)  This will be revamped later on so that all files are created in ./scratch and then cleaned up in post-processing.