### PR TITLE
Functionality for using "seamless" FP data (with generic file names)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -30,17 +30,69 @@ In 2019, GEOS LDAS version control transferred from CVS to Git.
 This README file contains the history of stable GEOSldas versions ("tags") in Git, followed by older, CVS LDASsa and GEOSldas versions and change logs.
 
 
-[Unreleased] Features:
---------------------
-_These are additions put in development, that will be in the next stable tag_
-
-
-
-
-
-Overview of Git tags:
+Overview of Git Releases:
 ============================
 
+[v17.9.0-beta.5](https://github.com/GEOS-ESM/GEOSldas/releases/tag/v17.9.0-beta.5) - 2020-05-11
+------------------------------
+- Pre-release meant for use under SLES12 at NCCS.  Still works for SLES11.
+
+- New/Updated Science Functionality:
+
+  - Forecast error covariance inflation with scalar (globally constant) factor.
+
+- New/Updated Infrastructure:
+
+  - Support for GEOS FP forcing with generic ("seamless") file names.
+  - Resource parameter changes:
+    - Renamed NUM_ENSEMBLE to NUM_LDAS_ENSEMBLE in "exeinp" file to be consistent with LDAS.rc.
+    - Renamed MONTHLY_OUTPUT to POSTPROC_HIST.
+  - Updated utilities to MAPL v2.1.3, ESMA_env v2.1.3+intel19.1.0.
+  
+- Bug Fixes and Other Minor Changes:
+
+  - Added basic protections for concatenation of sub-daily into daily nc4 files and for generation of monthly-mean nc4 files.
+  - Write ObsFcstAna and smapL4SMaup files into ./scratch, then move to ana/ens_avg/year/month dir in postprocessing.
+  - Some cleanup of obsolete LDASsa code.
+
+------------------------------
+[v17.9.0-beta.4-SLES12](https://github.com/GEOS-ESM/GEOSldas/releases/tag/v17.9.0-beta.4-SLES12) - 2020-04-24
+------------------------------
+- Pre-release meant for use under SLES12 at NCCS, otherwise identical to v17.9.0-beta.4-SLES11.
+- Works under SLES12 using the Intel-19 compiler.
+- Also works under SLES11 using the Intel-18 compiler but is not zero-diff across compilers/operating systems.
+
+------------------------------
+[v17.9.0-beta.4-SLES11](https://github.com/GEOS-ESM/GEOSldas/releases/tag/v17.9.0-beta.4-SLES11) - 2020-04-23
+------------------------------
+- Pre-release meant for use under SLES11 at NCCS. Under SLES12, use v17.9.0-beta.4-SLES12 (or newer).
+- Uses the Intel-18 compiler and also appears to work under SLES12. However, LDASsa with Intel-18 under SLES12 was found to create bad Fortran sequential binary files out of a subroutine that is very similar in LDASsa and GEOSldas.
+- Zero-diff vs. v17.9.0-beta.3 for Catchment only (except SMAP L1C Tb fore-minus-aft check).
+- Not zero-diff for CatchCN (via v1.8.3 of GEOS_GCMGridComp).
+
+- New/Updated Science Functionality:
+
+  - Resurrected SMAP L1C Tb fore-minus-aft check.
+
+- New/Updated Infrastructure:
+
+  - Updated utilities to MAPL v2.1.1, ESMA_env v2.1.1., ESMA_cmake v3.0.1.
+  - New GEOS_SurfaceGridComp.rc file (via v1.8.3 of GEOS_GCMGridComp).
+  - Parallel post-processing.
+  - Cross-stream support for FP f525_p5 forcing.
+  - ~sbatch~ submission for pre-processing of restarts to comply with SLES12 requirements.
+  - Subdaily-to-daily concatenation processes before month is complete.
+  - Temporary solution to create directories for ObsFcstAna files to enable extending an existing GEOSldas run without going through setup.
+
+- Bug Fixes and Other Minor Changes:
+
+  - Updated README.md.
+  - ~obspertrseed~ restart file name when restarting from existing run.
+  - Subdaily-to-daily nc4 concatenation (indent error).
+  - Fixes for GNU compiler in debug mode.
+  - Fixed ~landpert~ checkpoint output when on cube-sphere tiles.
+
+------------------------------
 [v17.9.0-beta.3](https://github.com/GEOS-ESM/GEOSldas/releases/tag/v17.9.0-beta.3) - 2020-03-18
 ------------------------------
 - Additional RESTART options, incl. from re-tiling MERRA-2, FP, or other restarts on different tile space or with different boundary conditions
@@ -239,6 +291,15 @@ reichle-LDASsa_m3-16_6_p1                9 Jul 2018  Added GEOS-5.21 FP function
                                                      (patch targeted for NRv7.2 and SMAP L4_SM ops)
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 reichle-LDASsa_m3-16_6_p2                7 Mar 2019  Added GEOS-5.22 FP functionality
+                                                     (patch targeted for NRv7.2 and SMAP L4_SM ops)
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+reichle-LDASsa_m3-16_6_p3               30 Jan 2020  Added GEOS-5.25 FP functionality
+                                                     (patch targeted for NRv7.2 and SMAP L4_SM ops)
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+reichle-LDASsa_m3-16_6_p4                3 Apr 2020  Added GEOS-5.25_p5 FP functionality
+                                                     (patch targeted for NRv7.2 and SMAP L4_SM ops)
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+reichle-LDASsa_m3-16_6_p4_SLES12        14 Apr 2020  SLES12 version of *_p4 tag -- NOT zero-diff!!
                                                      (patch targeted for NRv7.2 and SMAP L4_SM ops)
 
 -------------------------------------------------------------------------------------

--- a/doc/README.metforcing_and_bcs.md
+++ b/doc/README.metforcing_and_bcs.md
@@ -182,7 +182,7 @@ COMMONLY USED values for `MET_TAG`:
 
   MET_TAG  : cross_FP      ! stitch FP experiment names across years 
 
-  MET_TAG  : GEOS.fp.asm   ! "seamless" FP files (published/uniform file names, ~same result as cross_FP)
+  MET_TAG  : GEOS.fp.asm   ! "seamless" FP files (published/generic file names, ~same result as cross_FP)
 ```
 
 #### FP with precip corrections as in pre-beta SMAP L4_SM products

--- a/doc/README.metforcing_and_bcs.md
+++ b/doc/README.metforcing_and_bcs.md
@@ -72,7 +72,7 @@ SMAP_Nature_v04, SMAP_Nature_v04.1
   MET_PATH : /discover/nobackup/projects/gmao/merra/iau/merra_land/GEOS5_land_forcing/
 ```
 
-SMAP_Nature_v05
+SMAP_Nature_v05, v7.2, v8.1;  SMAP L4_SM Version 4, Version 5
 ```
   MET_PATH : /discover/nobackup/projects/gmao/merra/iau/merra_land/MERRA2_land_forcing/  ! before 1/1/2015
   MET_PATH : /discover/nobackup/projects/gmao/merra/iau/merra_land/GEOS5_land_forcing/   ! after  1/1/2015
@@ -168,12 +168,21 @@ COMMONLY USED values for `MET_TAG`:
   MET_TAG  : cross_d5124_RPFPIT               ! uses "late-look" through present
 ```
 
-#### FP
+#### GEOS FP
 ```
-  MET_TAG  : e5110_fp
-  MET_TAG  : e5130_fp
-  MET_TAG  : e5131_fp
-  MET_TAG  : cross_FP
+  MET_TAG  : e5110_fp      ! starting 11 Jun 2013
+  MET_TAG  : e5130_fp      ! starting 20 Aug 2014
+  MET_TAG  : e5131_fp      ! starting  1 May 2015
+  MET_TAG  : f516_fp       ! starting 24 Jan 2017
+  MET_TAG  : f517_fp       ! starting  1 Nov 2017
+  MET_TAG  : f521_fp       ! starting 11 Jul 2018
+  MET_TAG  : f522_fp       ! starting 13 Mar 2019
+  MET_TAG  : f525_fp       ! starting 30 Jan 2020
+  MET_TAG  : f525_p5_fp    ! starting  7 Apr 2020
+
+  MET_TAG  : cross_FP      ! stitch FP experiment names across years 
+
+  MET_TAG  : GEOS.fp.asm   ! "seamless" FP files (published/uniform file names, ~same result as cross_FP)
 ```
 
 #### FP with precip corrections as in pre-beta SMAP L4_SM products
@@ -184,7 +193,7 @@ COMMONLY USED values for `MET_TAG`:
 #### SMAP_Nature_v03
 ```
   MET_TAG  : cross_RPFPIT__precCPCUG5RPFPITv1                ! before 1/1/2014
-  MET_TAG  : cross_FP__precCPCUG5FPv1		            ! after  1/1/2014
+  MET_TAG  : cross_FP__precCPCUG5FPv1		             ! after  1/1/2014
 ```
 
 #### SMAP_Nature_v04      
@@ -199,7 +208,7 @@ COMMONLY USED values for `MET_TAG`:
   MET_TAG  : cross_FP__precCPCUG5FPv2                        ! after  1/1/2015
 ```
 
-#### SMAP_Nature_v05
+#### SMAP_Nature_v05, v7.2, v8.1;  SMAP L4_SM Version 4, Version 5
 ```
   MET_TAG  : M2COR_cross__precCPCUGPCP22clim_MERRA2_BMTXS    ! before 1/1/2015
   MET_TAG  : cross_FP__precCPCUG5FPv3                        ! after  1/1/2015
@@ -259,7 +268,7 @@ COMMONLY USED boundary conditions (bcs):
   BCS_PATH = /discover/nobackup/projects/gmao/ssd/land/l_data/geos5/bcs/CLSM_params/mkCatchParam_SMAP_L4SM_v002/
 ```
 
-#### Icarus-NL ("New Land")
+#### Icarus-NL ("New Land"), SMAP_Nature_v7.2
 ```
   BCS_PATH = /discover/nobackup/ltakacs/bcs/Icarus-NL/
 ```
@@ -269,8 +278,7 @@ Notes:
 - This path remains in place to permit recreating experiments that have used this path.
 - The sub-directory "Icarus-NL_MERRA-2/" contains the "new land" bcs.  The string "MERRA-2" in this sub-directory name refers to ocean bcs that are not relevant for GEOSldas.
 
-
-#### Icarus-NL ("New Land") v2
+#### Icarus-NLv2, SMAP L4_SM Version 4
 ```
   BCS_PATH = /discover/nobackup/ltakacs/bcs/Icarus-NLv2/
 ```
@@ -279,7 +287,7 @@ Notes:
 - Icarus-NLv2 is a update to Icarus-NL bcs. A patch has been applied to files green*.data, nirdf*.dat, and visdf*.dat. 
 - DEFAULT for GEOSldas v17.8.0 
 	
-#### Icarus-NL ("New Land") v3
+#### Icarus-NLv3, SMAP_Nature_v8.1, SMAP L4_SM Version 5
 ```
   BCS_PATH = /discover/nobackup/ltakacs/bcs/Icarus-NLv3/
 ```

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -4569,10 +4569,10 @@ contains
     
     if (.not. file_exists) then
        if(master_logit) then
-          print*, trim(Iam) // ': Could not find any of the following files:'
-          print*, trim(fname_full_tmp1)
-          print*, trim(fname_full_tmp2)
-          print*, trim(fname_full)
+          print '(400A)',  trim(Iam) // ': Could not find any of the following files:'
+          print '(400A)',  trim(fname_full_tmp1)
+          print '(400A)',  trim(fname_full_tmp2)
+          print '(400A)',  trim(fname_full)
        endif
     endif    
 
@@ -4623,7 +4623,7 @@ contains
          ierr=nf90_open(fname_full,NF90_NOWRITE, fid)
 
          if(master_logit) then
-           write(logunit,*) "opening file: "//trim(fname_full)
+           write(logunit,'(400A)') "opening file: "//trim(fname_full)
          endif
          ASSERT_( ierr == nf90_noerr)
          call FileOpenedHash%put(fname_full,fid)
@@ -4906,10 +4906,10 @@ contains
     
     if( .not. file_exists ) then
        if(master_logit) then 
-          print*, trim(Iam) // ': Could not find any of the following files:'
-          print*, trim(fname_full_tmp1)
-          print*, trim(fname_full_tmp2)
-          print*, trim(fname_full)
+          print '(400A)',  trim(Iam) // ': Could not find any of the following files:'
+          print '(400A)',  trim(fname_full_tmp1)
+          print '(400A)',  trim(fname_full_tmp2)
+          print '(400A)',  trim(fname_full)
        endif
     endif
     

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -3006,15 +3006,16 @@ contains
           elseif (                                                               &
                (j==1)                                       .and.                &
                (tmp_init)                                   .and.                &
-               (trim(GEOSgcm_defs(GEOSgcm_var,2))=='tavg')             ) then
+               (trim(GEOSgcm_defs(GEOSgcm_var,2))=='tavg')  .and.                &
+               (master_logit)                                       ) then
              
-             if ((.not. MERRA_file_specs) ) write (logunit,'(400A)')  &
+             if (.not. MERRA_file_specs)  write (logunit,'(400A)')               &
                   'NOTE: Initialization. Data from tavg file are not used '  //  &
                   'with lfo inst/tavg forcing, but dummy values must be '    //  &
                   'read from some file for backward compatibility with '     //  &
                   'MERRA forcing.'
              
-             if(master_logit) write (logunit,*) 'try again with different file...'
+             write (logunit,*) 'try again with different file...'
              
           else
              

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -4554,9 +4554,11 @@ contains
        
        tmpindend = len_trim(fname_full)
        tmpind    = len_trim(file_ext)
-           
-       fname_full( tmpindend - tmpind - 1 ) = '2'      ! --> *.V02.nc4
        
+       tmpind    = tmpindend - tmpind - 3
+       
+       fname_full( tmpind:tmpind+2 ) = 'V02'           ! --> *.V02.nc4
+              
        inquire(file=fname_full, exist=file_exists)
     
     end if
@@ -4889,8 +4891,10 @@ contains
        
        tmpindend = len_trim(fname_full)
        tmpind    = len_trim(file_ext)
-           
-       fname_full( tmpindend - tmpind - 1 ) = '2'      ! --> *.V02.nc4
+       
+       tmpind    = tmpindend - tmpind - 3
+
+       fname_full( tmpind:tmpind+2 ) = 'V02'           ! --> *.V02.nc4
        
        inquire(file=fname_full, exist=file_exists)
     

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -4450,7 +4450,7 @@ contains
     ! local variables
     
     character(300) :: fname, fname_full_tmp
-    character( 13) :: time_stamp
+    character( 14) :: time_stamp
     character(  4) :: YYYY,  HHMM
     character(  2) :: MM,    DD  
 
@@ -4482,7 +4482,7 @@ contains
        
     else
        
-       time_stamp      = YYYY // MM // DD // '_' // trim(HHMM)
+       time_stamp      = YYYY // MM // DD // '_' // trim(HHMM) // 'z'
        
     end if
     
@@ -4495,14 +4495,15 @@ contains
        ! e.g.: GEOS.fp.asm.inst1_2d_lfo_Nx.20200507_0000.V01.nc4
 
        fname = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '.' // &
-            trim(time_stamp) // '.V01.' // file_ext
+            trim(time_stamp(1:13)) // '.V01.' // file_ext
        
     else
 
        ! e.g.: f525_p5_fp.inst1_2d_lfo_Nx.20200507_0000z.nc4
-
+       ! e.g.: MERRA2_400.inst1_2d_lfo_Nx.20200507.nc4
+       
        fname = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '.' // &
-            trim(time_stamp) // 'z.' // file_ext
+            trim(time_stamp) // '.' // file_ext
        
     end if
     


### PR DESCRIPTION
Addresses issue #148

- read "seamless" GEOS FP forcing data with generic file names from year/month/day directories
- look for product counter "V02" if file with product counter "V01" cannot be found
- documentation updates 

Successfully tested for zero-diff by @gmao-rreichle on 11 May 2020 (full suite of GEOSldas Nightly Tests).
