### PR TITLE
Tb HISTORY output, bug fixes, and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,7 @@ See below for how to build the model in multiple steps.
 
 ## How to Set Up and Run GEOSldas
 
-a) Obtain an interactive _compute_ node:
-
-```
-xalloc --nodes=1
-```
-
-The GEOSldas setup script uses MPI and **must** be run on a compute node.  (For NCCS SLES11, a login node also works.)
-
-
-b) On the _compute_ node, set up the job as follows:
+a) Set up the job as follows:
 
 ```
 cd (build_path)/GEOSldas/install/bin
@@ -113,9 +104,9 @@ ldas_setup sample -h
 ldas_setup setup  -h
 ```
 
-Configure the experiment output by editing the ```HISTORY.rc``` file.
+b) Configure the experiment output by editing the ```./run/HISTORY.rc``` file as needed.
 
-c) Finally, run the job:
+c) Run the job:
 ```
 cd [exp_path]/[exp_name]/run/
 sbatch lenkf.j

--- a/src/Applications/LDAS_App/GEOSldas_HIST.rc
+++ b/src/Applications/LDAS_App/GEOSldas_HIST.rc
@@ -16,6 +16,7 @@ COLLECTIONS:
 #EASE            'tavg24_1d_lnd_Nt'	
 #CUBE            'tavg24_2d_lnd_Nx'
 #ASSIM           'SMAP_L4_SM_gph'
+#                'inst1_1d_lnr_Nt'
 #                'catch_progn_incr'
            ::
 
@@ -323,9 +324,21 @@ COLLECTIONS:
                                'TA'         , 'ENSAVG'      , 'temp_lowatmmodlay'                 ,
                                'QA'         , 'ENSAVG'      , 'specific_humidity_lowatmmodlay'    ,
                                'UU'         , 'ENSAVG'      , 'windspeed_lowatmmodlay'            ,
-                               'GRN'        , 'VEGDYN'  , 'vegetation_greenness_fraction'     ,
-                               'LAI'        , 'VEGDYN'  , 'leaf_area_index'                   ,
+                               'GRN'        , 'VEGDYN'      , 'vegetation_greenness_fraction'     ,
+                               'LAI'        , 'VEGDYN'      , 'leaf_area_index'                   ,
                                ::
+
+  inst1_1d_lnr_Nt.descr:        'Tile-space,1-Hourly,Instantaneous,Single-Level,Assimilation,Land Nature Run Diagnostics',
+  inst1_1d_lnr_Nt.template:     '%y4%m2%d2_%h2%n2z.bin' ,
+  inst1_1d_lnr_Nt.mode:         'instantaneous' ,
+  inst1_1d_lnr_Nt.frequency:    010000 ,
+  inst1_1d_lnr_Nt.ref_time:     000000,
+  inst1_1d_lnr_Nt.fields:      'TPSURF'                     , 'ENSAVG'      , 'surface_temp'                      ,
+                               'TSOIL1TILE'                 , 'ENSAVG'      , 'soil_temp_layer1'                  ,
+                               'TPSNOW'                     , 'ENSAVG'      , 'snow_temp_layer1'                  ,
+                               'TB_LAND_1410MHZ_40DEG_HPOL' , 'LANDASSIM'   , 'tb_h'                              ,
+                               'TB_LAND_1410MHZ_40DEG_VPOL' , 'LANDASSIM'   , 'tb_v'                              ,
+			       ::
 
   catch_progn_incr.descr:       'Tile-space,3-Hourly,Instantaneous,Single-Level,Assimilation,Ensemble-Average Land Prognostics Increments',
   catch_progn_incr.template:    '%y4%m2%d2_%h2%n2z.bin',

--- a/src/Applications/LDAS_App/GEOSldas_LDAS.rc
+++ b/src/Applications/LDAS_App/GEOSldas_LDAS.rc
@@ -38,7 +38,7 @@ LSM_CHOICE: 1
 #
 #      Specify extremities of lat/lon rectangle:
 #         Max lat/lon range: lon=-180:180, lat=-90:90.
-#      If only whitelist should be used, specify dummy valuessuch that:
+#      If only whitelist should be used, specify dummy values such that:
 #         MINLON > MAXLON and MINLAT > MAXLAT.
 #
 # MINLON: -180.

--- a/src/Applications/LDAS_App/GEOSldas_LDAS.rc
+++ b/src/Applications/LDAS_App/GEOSldas_LDAS.rc
@@ -46,7 +46,7 @@ LSM_CHOICE: 1
 # MINLAT:  -90.
 # MAXLAT:   90.
 #
-#      Specify path and filenames for blacklist and whitelist files:
+#      Path and filenames for blacklist and whitelist files.
 #      (May leave blank.)
 #
 # BLACK_FILE: '' 
@@ -63,8 +63,8 @@ MET_HINTERP: 1
 
 # ---- Specify if running model only or data assimilation
 #
-#  NO  : model only (DEFAULT; with --runmodel option)
-#  YES : assimilation (without --runmodel option)
+#  NO  : model only, with or without perturbations (default)
+#  YES : assimilation (full land analysis or just processing of obs for "innovations" output)
 #
 LAND_ASSIM: NO
 

--- a/src/Applications/LDAS_App/GEOSldas_LDAS.rc
+++ b/src/Applications/LDAS_App/GEOSldas_LDAS.rc
@@ -164,10 +164,6 @@ SURFRC: LDAS.rc
 #
 DYCORE: none
 
-# ---- Only one surface level
-#
-LM: 1
-
 # ---- For MAPL_RestartOptional
 #
 MAPL_ENABLE_BOOTSTRAP: YES

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -44,7 +44,7 @@ class LDASsetup:
             'RESTART_DOMAIN','RESTART_ID','BCS_PATH','TILING_FILE','GRN_FILE','LAI_FILE','NIRDF_FILE',
             'VISDF_FILE','CATCH_DEF_FILE','NDVI_FILE',
             'NML_INPUT_PATH','HISTRC_FILE','RST_FROM_GLOBAL','JOB_SGMT','NUM_SGMT','POSTPROC_HIST',
-            'MINLON','MAXLON','MINLAT','MAXLAT','BLACK_FILE','WHITE_FILE','MWRTM_FILE']
+            'MINLON','MAXLON','MINLAT','MAXLAT','BLACK_FILE','WHITE_FILE','MWRTM_FILE','GRIDNAME']
 
 
         # ------
@@ -104,6 +104,7 @@ class LDASsetup:
         self.has_geos_pert = False
         self.has_ldassa_pert = False
         self.nSegments = 1
+        self.perturb = 0
         # ------
         # Read exe input file which is required to set up the dir
         # ------
@@ -142,6 +143,9 @@ class LDASsetup:
         assert not os.path.isdir(_mydir), 'Dir [%s] already exists!' % _mydir
         _mydir = None
         _first_ens_id = int(self.rqdExeInp.get('FIRST_ENS_ID',0))
+        self.perturb = int(self.rqdExeInp.get('PERTURBATIONS',0))
+        if self.nens > 1:
+           self.perturb = 1
         self.ensdirs  = ['ens%04d'%iens for iens in range(_first_ens_id, self.nens  + _first_ens_id)]
         self.ensids   = ['%04d'%iens    for iens in range(_first_ens_id, self.nens  + _first_ens_id)]
         if (self.nens == 1) :
@@ -275,8 +279,6 @@ class LDASsetup:
         if 'GRIDNAME' not in self.rqdExeInp :
             tmptile =self.rqdExeInp['TILING_FILE']
             self.rqdExeInp['GRIDNAME']  = linecache.getline(tmptile, 3).strip()
-        if 'RESOLUTION' not in self.rqdExeInp :
-            self.rqdExeInp['RESOLUTION']= os.path.split(os.path.split(self.rqdExeInp['BCS_PATH'])[0])[1]
 
         if 'LSM_CHOICE' not in self.rqdExeInp:
             self.rqdExeInp['LSM_CHOICE'] = 1
@@ -809,14 +811,14 @@ class LDASsetup:
                     vegdynRstFile0 = vegdynRstFile
             else :    
                 vegdynRstFile = vegdynRstFile0
-            _perturb = 1 if self.nens > 1 else 0
-            if (self.has_geos_pert and _perturb == 1) :
+
+            if (self.has_geos_pert and self.perturb == 1) :
                 pertRstFile = rstpath+ens +'/'+ y4m2+'/'+self.rqdExeInp['RESTART_ID']+'.landpert_internal_rst.'+y4m2d2_h2m2
                 pertLocal   = self.rstdir+ens +'/'+ y4m2+'/'+self.rqdExeInp['EXP_ID']+'.landpert_internal_rst.'+y4m2d2_h2m2
                 shutil.copy(pertRstFile,pertLocal)
                 pertRstFile = pertLocal
 
-            if (self.has_ldassa_pert and _perturb == 1 ) :
+            if (self.has_ldassa_pert and self.perturb == 1 ) :
                 pertRstFile = rstpath+ens +'/'+ y4m2+'/'+self.rqdExeInp['RESTART_ID']+'.'+ens+'.pert_ldas_rst.'+y4m2d2_h2m2+'z.bin'
                 pertLocal   = self.rstdir+ens +'/'+ y4m2+'/'+self.rqdExeInp['EXP_ID']+'.landpert_internal_rst.'+y4m2d2_h2m2
                 print "Convert LDASsa pert " + ensid + " rst to GEOSldas rst"
@@ -828,7 +830,7 @@ class LDASsetup:
 
             os.symlink(catchRstFile, myCatchRst)
             os.symlink(vegdynRstFile,  myVegRst)
-            if ( (self.has_geos_pert or self.has_ldassa_pert) and  _perturb == 1 ):
+            if ( (self.has_geos_pert or self.has_ldassa_pert) and  self.perturb == 1 ):
                os.symlink(pertRstFile,  myPertRst)
 
         # catch_param restar file
@@ -957,9 +959,8 @@ class LDASsetup:
                     if '-CF' in self.rqdExeInp['GRIDNAME'] :
                         GRID ='CUBE ' + self.rqdExeInp['GRIDNAME'] + ' ' +tmprcfile
                     _assim = '1' if self.assim else '0'
-                    _perturb = '1' if self.nens > 1 else '0'
                     cmd ='./process_hist.csh '+ str(self.rqdExeInp['LSM_CHOICE']) + ' ' + str(self.rqdExeInp['AEROSOL_DEPOSITION']) + \
-                          ' ' + GRID + ' ' + str(self.rqdExeInp['RUN_IRRIG']) + ' ' + _assim + ' '+ _perturb
+                          ' ' + GRID + ' ' + str(self.rqdExeInp['RUN_IRRIG']) + ' ' + _assim + ' '+ str(self.nens)
                     print(cmd)
                     os.system(cmd)
                     #sp.call(cmd)       
@@ -1008,8 +1009,9 @@ class LDASsetup:
                 # create BC in rc file
                 tmpl_ = ''
                 if self.nens >1 :
-                   ldasrcInp['PERTURBATIONS'] ='1'
                    tmpl_='%s' 
+                if self.perturb == 1:
+                   ldasrcInp['PERTURBATIONS'] ='1'
                 bcval=['../input/green','../input/lai','../input/ndvi','../input/nirdf','../input/visdf']
                 bckey=['GREEN','LAI','NDVI','NIRDF','VISDF']
                 for key, val in zip(bckey,bcval):
@@ -1031,8 +1033,7 @@ class LDASsetup:
         
                 rstkey=[catch_,'VEGDYN']
                 rstval=[self.catch,'vegdyn']
-                _perturb = 1 if self.nens > 1 else 0
-                if((self.has_ldassa_pert or self.has_geos_pert) and _perturb == 1) :
+                if((self.has_ldassa_pert or self.has_geos_pert) and self.perturb == 1) :
                    rstkey=[catch_,'VEGDYN','LANDPERT']
                    rstval=[self.catch,'vegdyn','landpert']
 
@@ -1041,38 +1042,36 @@ class LDASsetup:
                    valn='../input/restart/mwrtm_param_rst'
                    ldasrcInp[keyn]= valn
 
+                if self.nens > 1 :
+                   keyn='ENS_ID_WIDTH'
+                   valn='4'
+                   ldasrcInp[keyn]= valn
+
                 if self.has_landassim_seed and self.assim :
                    keyn='LANDASSIM_OBSPERTRSEED_RESTART_FILE'
-                   valn='../input/restart/landassim_obspertrseed%s_rst'
+                   valn='../input/restart/landassim_obspertrseed'+tmpl_+'_rst'
                    ldasrcInp[keyn]= valn
 
                 if self.assim: 
                    keyn='LANDASSIM_OBSPERTRSEED_CHECKPOINT_FILE'
-                   valn='landassim_obspertrseed%s_checkpoint'
-                   ldasrcInp[keyn]= valn
-
-                ensid =""
-                if self.nens > 1 :
-                   ensid ="%s"
-                   keyn='ENS_ID_WIDTH'
-                   valn='4'
+                   valn='landassim_obspertrseed'+tmpl_+'_checkpoint'
                    ldasrcInp[keyn]= valn
        
                 for key,val in zip(rstkey,rstval) :
                     keyn = key+ '_INTERNAL_RESTART_FILE'
-                    valn = '../input/restart/'+val+ensid+'_internal_rst'
+                    valn = '../input/restart/'+val+tmpl_+'_internal_rst'
                     ldasrcInp[keyn]= valn
                         
                 # checkpoint file and its type
                 keyn = catch_ + '_INTERNAL_CHECKPOINT_FILE'
-                valn = self.catch+ensid+'_internal_checkpoint'
+                valn = self.catch+tmpl_+'_internal_checkpoint'
                 ldasrcInp[keyn]= valn
 
                 # for lat/lon and EASE tile space, specify LANDPERT checkpoint file here (via MAPL);
                 # for cube-sphere tile space, Landpert GC will set up LANDPERT checkpoint file 
-                if('-CF' not in self.rqdExeInp['GRIDNAME'] and _perturb == 1):
+                if('-CF' not in self.rqdExeInp['GRIDNAME'] and self.perturb == 1):
                     keyn = 'LANDPERT_INTERNAL_CHECKPOINT_FILE'
-                    valn = 'landpert'+ensid+'_internal_checkpoint'
+                    valn = 'landpert'+tmpl_+'_internal_checkpoint'
                     ldasrcInp[keyn]= valn
                     
     

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -896,18 +896,17 @@ class LDASsetup:
         etcdir = self.blddirLn + '/etc'
 
         #defalt nml
-        default_nml = glob.glob(etcdir+'/LDASsa_DEFAULT*.nml')
+        default_nml = glob.glob(etcdir+'/LDASsa_DEFAULT_inputs_*.nml')
         for nmlfile in default_nml:
             shortfile=self.rundir+'/'+nmlfile.split('/')[-1]
             shutil.copy2(nmlfile, shortfile)
          # special nml
         special_nml=[]
         if 'NML_INPUT_PATH' in self.rqdExeInp :
-            special_nml = glob.glob(self.rqdExeInp['NML_INPUT_PATH']+'/*SPECIAL*nml')
+            special_nml = glob.glob(self.rqdExeInp['NML_INPUT_PATH']+'/LDASsa_SPECIAL_inputs_*.nml')
         for nmlfile in special_nml:
-            if (_nens > 1) :
-                shortfile=nmlfile.split('/')[-1]
-                shutil.copy2(nmlfile, self.rundir+'/'+shortfile)
+            shortfile=nmlfile.split('/')[-1]
+            shutil.copy2(nmlfile, self.rundir+'/'+shortfile)
 
         # get optimzed NX and IMS
         if os.path.isfile('optimized_distribution'):

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -772,7 +772,7 @@ class LDASsetup:
                 catchRstFile = self.exphome+'/'+exp_id+'/mk_restarts/'+self.catch+'_internal_rst.'+YYYYMMDD
 
             # catchment restart file
-            print 'catchRstFile1: ' +  catchRstFile
+            print 'catchRstFile: ' +  catchRstFile
             if os.path.isfile(catchRstFile) :
 
                 catchLocal = self.rstdir+ens +'/'+ y4m2+'/'+self.rqdExeInp['EXP_ID']+'.'+self.catch+'_internal_rst.'+y4m2d2_h2m2
@@ -1536,27 +1536,27 @@ def parseCmdLine():
         help='input file with arguments for SLURM',
         )
     p_setup.add_argument(
-        '--runmodel',
-        help='obsolete, no effect any more',
-        action='store_true',
+        '--account',
+        help='replace computing/sponsor account in batinp file',
+        type=str, default='None'
         )
     p_setup.add_argument(
-        '--account',
-        help='replace the account in batinpfile)',
-        type=str, default='None'
+        '--runmodel',
+        help='Obsolete.',
+        action='store_true',
         )
     spltgrp = p_setup.add_mutually_exclusive_group()
     spltgrp.add_argument(
         '--daysperjob',
         type=int,
         metavar='N',
-        help='This option is no longer available.  Use NUM_SGMT and JOB_SGMT in exeinp file.',
+        help='Obsolete.  Use NUM_SGMT and JOB_SGMT in exeinp file.',
         )
     spltgrp.add_argument(
         '--monthsperjob',
         type=int,
         metavar='N',
-        help='This option is no longer available.  Use NUM_SGMT and JOB_SGMT in exeinp file.',
+        help='Obsolete.  Use NUM_SGMT and JOB_SGMT in exeinp file.',
         )
 
     return p.parse_args()

--- a/src/Applications/LDAS_App/lenkf.j.template
+++ b/src/Applications/LDAS_App/lenkf.j.template
@@ -502,7 +502,7 @@ EOF
             set dayl = `echo $time_steps[$LEN] | cut -c1-8`
             set day1 = `echo $time_steps[1] | cut -c1-8`
             @ NAVAIL = ($dayl - $day1) + 1
-          else if( $LEN_ !=0 ) then
+          else if( $LEN_ != 0 ) then
             set dayl = `echo $time_steps_[$LEN] | cut -c1-8`
             set day1 = `echo $time_steps_[1] | cut -c1-8`
             @ NAVAIL = ($dayl - $day1) + 1

--- a/src/Applications/LDAS_App/mwrtm_bin2nc4.F90
+++ b/src/Applications/LDAS_App/mwrtm_bin2nc4.F90
@@ -20,30 +20,30 @@ PROGRAM mwrtm_bin2nc4
   character(len=:),allocatable :: shnms(:)
   type(mwRTM_param_type), allocatable :: mwp(:)
   integer :: unitnum
-  logical :: is_nodata
+  logical :: mwp_nodata
 
 
   nVars = 18
-  shnms =[ &
-'MWRTM_VEGCLS   ',&
-'MWRTM_SOILCLS  ',&
-'MWRTM_SAND     ',&
-'MWRTM_CLAY     ',&
-'MWRTM_POROS    ',&
-'MWRTM_WANGWT   ',&
-'MWRTM_WANGWP   ',&
-'MWRTM_RGHHMIN  ',&
-'MWRTM_RGHHMAX  ',&
-'MWRTM_RGHWMIN  ',&
-'MWRTM_RGHWMAX  ',&
-'MWRTM_RGHNRH   ',&
-'MWRTM_RGHNRV   ',&
-'MWRTM_RGHPOLMIX',&
-'MWRTM_OMEGA    ',&
-'MWRTM_BH       ',&
-'MWRTM_BV       ',&
-'MWRTM_LEWT     ']
-
+  shnms = [              &
+       'MWRTM_VEGCLS   ',&
+       'MWRTM_SOILCLS  ',&
+       'MWRTM_SAND     ',&
+       'MWRTM_CLAY     ',&
+       'MWRTM_POROS    ',&
+       'MWRTM_WANGWT   ',&
+       'MWRTM_WANGWP   ',&
+       'MWRTM_RGHHMIN  ',&
+       'MWRTM_RGHHMAX  ',&
+       'MWRTM_RGHWMIN  ',&
+       'MWRTM_RGHWMAX  ',&
+       'MWRTM_RGHNRH   ',&
+       'MWRTM_RGHNRV   ',&
+       'MWRTM_RGHPOLMIX',&
+       'MWRTM_OMEGA    ',&
+       'MWRTM_BH       ',&
+       'MWRTM_BV       ',&
+       'MWRTM_LEWT     ']
+  
   ! processing command line agruments
   I = iargc()
   
@@ -123,7 +123,7 @@ PROGRAM mwrtm_bin2nc4
   read (unitnum) VAR;  mwp(1:NTILES)%lewt       =  VAR(1:NTILES)
 
   do i = 1, NTILES
-    call mwRTM_param_nodata_check( mwp(i), is_nodata )
+    call mwRTM_param_nodata_check( mwp(i), mwp_nodata )
   enddo
 
   VAR = real(mwp(1:NTILES)%vegcls)

--- a/src/Applications/LDAS_App/process_hist.csh
+++ b/src/Applications/LDAS_App/process_hist.csh
@@ -11,7 +11,7 @@ setenv    GRIDNAME $4
 setenv    HISTRC $5
 setenv    RUN_IRRIG $6
 setenv    ASSIM  $7
-setenv    PERTURB $8
+setenv    NENS $8
 
 echo $GRIDNAME
 
@@ -43,7 +43,7 @@ if($LSM_CHOICE == 2) then
    sed -i 's/>>>HIST_CATCHCN<<</''/g' $HISTRC
 endif
 
-if($PERTURB == 1 ) then
+if($NENS > 1) then
    set GridComp = ENSAVG
    sed -i 's|VEGDYN|'VEGDYN0000'|g' $HISTRC
 #   sed -i 's|DATAATM|'DATAATM0000'|g' $HISTRC

--- a/src/Applications/LDAS_App/tile_bin2nc4.F90
+++ b/src/Applications/LDAS_App/tile_bin2nc4.F90
@@ -187,20 +187,22 @@ PROGRAM tile_bin2nc4
 
     SELECT case (trim(SHORT_NAME))
 
-    ! For SM_L4
+    ! For SM_L4 
+    ! reichle, 20 May 2020: verified SHORT_NAME and corrected UNITS to match SMAP L4_SM Product Specs;  LONG_NAME (mostly) from GEOS_CatchGridComp.F90 
+
     case ('sm_surface');                       LONG_NAME = 'water_surface_layer';                                              UNITS = 'm3 m-3'
     case ('sm_rootzone');                      LONG_NAME = 'water_root_zone';                                                  UNITS = 'm3 m-3'
     case ('sm_profile');                       LONG_NAME = 'water_ave_prof';                                                   UNITS = 'm3 m-3'
     case ('sm_surface_wetness');               LONG_NAME = 'surface_soil_wetness';                                             UNITS = '1'
     case ('sm_rootzone_wetness');              LONG_NAME = 'root_zone_soil_wetness';                                           UNITS = '1'
     case ('sm_profile_wetness');               LONG_NAME = 'ave_prof_soil_wetness';                                            UNITS = '1'
-    case ('surface_temp');                     LONG_NAME = 'ave_catchment_temp_incl_snw';                                      UNITS = 'k' 
-    case ('soil_temp_layer1');                 LONG_NAME = 'soil_temperatures_layer_1';                                        UNITS = 'k' 
-    case ('soil_temp_layer2');                 LONG_NAME = 'soil_temperatures_layer_2';                                        UNITS = 'k' 
-    case ('soil_temp_layer3');                 LONG_NAME = 'soil_temperatures_layer_3';                                        UNITS = 'k' 
-    case ('soil_temp_layer4');                 LONG_NAME = 'soil_temperatures_layer_4';                                        UNITS = 'k' 
-    case ('soil_temp_layer5');                 LONG_NAME = 'soil_temperatures_layer_5';                                        UNITS = 'k' 
-    case ('soil_temp_layer6');                 LONG_NAME = 'soil_temperatures_layer_6';                                        UNITS = 'k' 
+    case ('surface_temp');                     LONG_NAME = 'ave_catchment_temp_incl_snw';                                      UNITS = 'K' 
+    case ('soil_temp_layer1');                 LONG_NAME = 'soil_temperatures_layer_1';                                        UNITS = 'K' 
+    case ('soil_temp_layer2');                 LONG_NAME = 'soil_temperatures_layer_2';                                        UNITS = 'K' 
+    case ('soil_temp_layer3');                 LONG_NAME = 'soil_temperatures_layer_3';                                        UNITS = 'K' 
+    case ('soil_temp_layer4');                 LONG_NAME = 'soil_temperatures_layer_4';                                        UNITS = 'K' 
+    case ('soil_temp_layer5');                 LONG_NAME = 'soil_temperatures_layer_5';                                        UNITS = 'K' 
+    case ('soil_temp_layer6');                 LONG_NAME = 'soil_temperatures_layer_6';                                        UNITS = 'K' 
     case ('snow_mass');                        LONG_NAME = 'snow_mass';                                                        UNITS = 'kg m-2'
     case ('snow_depth');                       LONG_NAME = 'snow_depth_in_snow_covered_area';                                  UNITS = 'm'
     case ('land_evapotranspiration_flux');     LONG_NAME = 'Evaporation_land';                                                 UNITS = 'kg m-2 s-1'
@@ -227,9 +229,18 @@ PROGRAM tile_bin2nc4
     case ('specific_humidity_lowatmmodlay');   LONG_NAME = 'specific_humidity_at_RefH';                                        UNITS = 'kg kg-1'
     case ('windspeed_lowatmmodlay');           LONG_NAME = 'wind_speed_at_RefH';                                               UNITS = 'm s-1'
     case ('vegetation_greenness_fraction');    LONG_NAME = 'greeness_fraction';                                                UNITS = '1' 
-    case ('leaf_area_index');                  LONG_NAME = 'leaf_area_index';                                                  UNITS = '1' 
-    ! Done for SM_L4
+    case ('leaf_area_index');                  LONG_NAME = 'leaf_area_index';                                                  UNITS = 'm2 m-2' 
 
+    ! additional defintions for SMAP Nature Run - reichle, 20 May 2020
+
+    case ('snow_temp_layer1');                 LONG_NAME = 'temperature_top_snow_layer';                                       UNITS = 'K' 
+    case ('tb_h')                              LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Hpol';                   UNITS = 'K' 
+    case ('tb_v')                              LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Vpol';                   UNITS = 'K' 
+    case ('TB_LAND_1410MHZ_40DEG_HPOL')        LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Hpol';                   UNITS = 'K' 
+    case ('TB_LAND_1410MHZ_40DEG_VPOL')        LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Vpol';                   UNITS = 'K' 
+ 
+    ! Done for SM_L4
+ 
     case ('Tair');       LONG_NAME = 'air_temperature_at_RefH';                                          UNITS = 'K' 
     case ('TA');         LONG_NAME = 'air_temperature_at_RefH';                                          UNITS = 'K' 
     case ('Qair');       LONG_NAME = 'specific_humidity_at_RefH';                                        UNITS = 'kg kg-1'
@@ -345,35 +356,39 @@ PROGRAM tile_bin2nc4
     case ('RMELTBC002'); LONG_NAME = 'flushed_out_black_carbon_mass_flux_from_the_bottom_layer_bin_2';   UNITS = 'kg m-2 s-1'
     case ('RMELTOC001'); LONG_NAME = 'flushed_out_organic_carbon_mass_flux_from_the_bottom_layer_bin_1'; UNITS = 'kg m-2 s-1'
     case ('RMELTOC002'); LONG_NAME = 'flushed_out_organic_carbon_mass_flux_from_the_bottom_layer_bin_2'; UNITS = 'kg m-2 s-1'
+ 
+    ! land assimilation increments for Catchment prognostic variables in coupled land-atmosphere DAS (#sqz 2020-01)
 
-!#sqz 2020-01 
-    case ('TCFSAT_INCR'); LONG_NAME = 'increment_canopy_temperature_saturated_zone'; UNITS = 'K' 
-    case ('TCFTRN_INCR'); LONG_NAME = 'increment_canopy_temperature_transition_zone'; UNITS = 'K'
-    case ('TCFWLT_INCR'); LONG_NAME = 'increment_canopy_temperature_wilting_zone'; UNITS = 'K'
-    case ('QCFSAT_INCR'); LONG_NAME = 'increment_canopy_specific_humidity_saturated_zone'; UNITS = 'kg kg-1'
-    case ('QCFTRN_INCR'); LONG_NAME = 'increment_canopy_specific_humidity_transition_zone'; UNITS = 'kg kg-1'
-    case ('QCFWLT_INCR'); LONG_NAME = 'increment_canopy_specific_humidity_wilting_zone'; UNITS = 'kg kg-1'
-    case ('CAPAC_INCR'); LONG_NAME = 'increment_interception_reservoir_capac'; UNITS = 'kg m-2'
-    case ('CATDEF_INCR'); LONG_NAME = 'increment_catchment_deficit'; UNITS = 'kg m-2'
-    case ('RZEXC_INCR'); LONG_NAME = 'increment_root_zone_excess'; UNITS = 'kg m-2'
-    case ('SRFEXC_INCR'); LONG_NAME = 'increment_surface_excess'; UNITS = 'kg m-2'
-    case ('GHTCNT1_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_1'; UNITS = 'J m-2'
-    case ('GHTCNT2_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_2'; UNITS = 'J m-2'
-    case ('GHTCNT3_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_3'; UNITS = 'J m-2' 
-    case ('GHTCNT4_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_4'; UNITS = 'J m-2'
-    case ('GHTCNT5_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_5'; UNITS = 'J m-2'
-    case ('GHTCNT6_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_6'; UNITS = 'J m-2'
-    case ('WESNN1_INCR');  LONG_NAME = 'increment_snow_mass_layer_1'; UNITS = 'kg m-2'
-    case ('WESNN2_INCR');  LONG_NAME = 'increment_snow_mass_layer_2'; UNITS = 'kg m-2'
-    case ('WESNN3_INCR');  LONG_NAME = 'increment_snow_mass_layer_3'; UNITS = 'kg m-2'
-    case ('HTSNNN1_INCR'); LONG_NAME = 'increment_heat_content_snow_layer_1'; UNITS = 'J m-2'
-    case ('HTSNNN2_INCR'); LONG_NAME = 'increment_heat_content_snow_layer_2'; UNITS = 'J m-2'
-    case ('HTSNNN3_INCR'); LONG_NAME = 'increment_heat_content_snow_layer_3'; UNITS = 'J m-2'
-    case ('SNDZN1_INCR'); LONG_NAME = 'increment_snow_depth_layer_1'; UNITS = 'm'
-    case ('SNDZN2_INCR'); LONG_NAME = 'increment_snow_depth_layer_2'; UNITS = 'm'
-    case ('SNDZN3_INCR'); LONG_NAME = 'increment_snow_depth_layer_3'; UNITS = 'm'
+    case ('TCFSAT_INCR');  LONG_NAME = 'increment_canopy_temperature_saturated_zone';                    UNITS = 'K' 
+    case ('TCFTRN_INCR');  LONG_NAME = 'increment_canopy_temperature_transition_zone';                   UNITS = 'K'
+    case ('TCFWLT_INCR');  LONG_NAME = 'increment_canopy_temperature_wilting_zone';                      UNITS = 'K'
+    case ('QCFSAT_INCR');  LONG_NAME = 'increment_canopy_specific_humidity_saturated_zone';              UNITS = 'kg kg-1'
+    case ('QCFTRN_INCR');  LONG_NAME = 'increment_canopy_specific_humidity_transition_zone';             UNITS = 'kg kg-1'
+    case ('QCFWLT_INCR');  LONG_NAME = 'increment_canopy_specific_humidity_wilting_zone';                UNITS = 'kg kg-1'
+    case ('CAPAC_INCR');   LONG_NAME = 'increment_interception_reservoir_capac';                         UNITS = 'kg m-2'
+    case ('CATDEF_INCR');  LONG_NAME = 'increment_catchment_deficit';                                    UNITS = 'kg m-2'
+    case ('RZEXC_INCR');   LONG_NAME = 'increment_root_zone_excess';                                     UNITS = 'kg m-2'
+    case ('SRFEXC_INCR');  LONG_NAME = 'increment_surface_excess';                                       UNITS = 'kg m-2'
+    case ('GHTCNT1_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_1';                            UNITS = 'J m-2'
+    case ('GHTCNT2_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_2';                            UNITS = 'J m-2'
+    case ('GHTCNT3_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_3';                            UNITS = 'J m-2' 
+    case ('GHTCNT4_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_4';                            UNITS = 'J m-2'
+    case ('GHTCNT5_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_5';                            UNITS = 'J m-2'
+    case ('GHTCNT6_INCR'); LONG_NAME = 'increment_soil_heat_content_layer_6';                            UNITS = 'J m-2'
+    case ('WESNN1_INCR');  LONG_NAME = 'increment_snow_mass_layer_1';                                    UNITS = 'kg m-2'
+    case ('WESNN2_INCR');  LONG_NAME = 'increment_snow_mass_layer_2';                                    UNITS = 'kg m-2'
+    case ('WESNN3_INCR');  LONG_NAME = 'increment_snow_mass_layer_3';                                    UNITS = 'kg m-2'
+    case ('HTSNNN1_INCR'); LONG_NAME = 'increment_heat_content_snow_layer_1';                            UNITS = 'J m-2'
+    case ('HTSNNN2_INCR'); LONG_NAME = 'increment_heat_content_snow_layer_2';                            UNITS = 'J m-2'
+    case ('HTSNNN3_INCR'); LONG_NAME = 'increment_heat_content_snow_layer_3';                            UNITS = 'J m-2'
+    case ('SNDZN1_INCR');  LONG_NAME = 'increment_snow_depth_layer_1';                                   UNITS = 'm'
+    case ('SNDZN2_INCR');  LONG_NAME = 'increment_snow_depth_layer_2';                                   UNITS = 'm'
+    case ('SNDZN3_INCR');  LONG_NAME = 'increment_snow_depth_layer_3';                                   UNITS = 'm'
+    !
+    ! default LONG_NAME and UNITS for nc4 files created by tile_bin2nc4.F90 (used for any SHORT_NAME not listed above):
+    !
+    case default;          LONG_NAME = 'not defined in tile_bin2nc4.F90';                                UNITS = 'not defined in tile_bin2nc4.F90';
 
-    case default;        LONG_NAME = 'Check_GridComp';   UNITS = 'No to fix getAttribute table in tile_bin2nc4.F90';
     end select
 
     if (present(LNAME)) str_atr = trim (LONG_NAME)

--- a/src/Applications/LDAS_App/tile_bin2nc4.F90
+++ b/src/Applications/LDAS_App/tile_bin2nc4.F90
@@ -234,10 +234,10 @@ PROGRAM tile_bin2nc4
     ! additional defintions for SMAP Nature Run - reichle, 20 May 2020
 
     case ('snow_temp_layer1');                 LONG_NAME = 'temperature_top_snow_layer';                                       UNITS = 'K' 
-    case ('tb_h')                              LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Hpol';                   UNITS = 'K' 
-    case ('tb_v')                              LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Vpol';                   UNITS = 'K' 
-    case ('TB_LAND_1410MHZ_40DEG_HPOL')        LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Hpol';                   UNITS = 'K' 
-    case ('TB_LAND_1410MHZ_40DEG_VPOL')        LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Vpol';                   UNITS = 'K' 
+    case ('tb_h');                             LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Hpol';                   UNITS = 'K' 
+    case ('tb_v');                             LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Vpol';                   UNITS = 'K' 
+    case ('TB_LAND_1410MHZ_40DEG_HPOL');       LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Hpol';                   UNITS = 'K' 
+    case ('TB_LAND_1410MHZ_40DEG_VPOL');       LONG_NAME = 'brightness_temperature_land_1410MHz_40deg_Vpol';                   UNITS = 'K' 
  
     ! Done for SM_L4
  

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -859,13 +859,6 @@ contains
        VERIFY_(status)
        call MAPL_TimerOff(MAPL, gcnames(igc))
 
-       ! ApplyPrognPert - moved: now before calculating ensemble average that is picked up by HISTORY; reichle 24 May 2020 
-       igc = LANDPERT(i)
-       call MAPL_TimerOn(MAPL, gcnames(igc))
-       call ESMF_GridCompRun(gcs(igc), importState=gim(igc), exportState=gex(igc), clock=clock, phase=4, userRC=status)
-       VERIFY_(status)
-       call MAPL_TimerOff(MAPL, gcnames(igc))
-       
        ! Use land's output as the input to calculate the ensemble average
        if (LSM_CHOICE == 1) then
           ! collect cat_param 
@@ -880,6 +873,16 @@ contains
              VERIFY_(status)
           endif
        endif
+
+       ! Should this be moved to the beginning of the loop to avoid the pollution ?
+       ! THIS MUST BE MOVED AT LEAST TO BEFORE THE "ENSAVG/phase=3" CALL IF ENSEMBLE STATS OTHER THAN THE AVERAGE
+       ! ARE COMPUTED - reichle, 14 May 2020
+       ! ApplyPrognPert
+       igc = LANDPERT(i)
+       call MAPL_TimerOn(MAPL, gcnames(igc))
+       call ESMF_GridCompRun(gcs(igc), importState=gim(igc), exportState=gex(igc), clock=clock, phase=4, userRC=status)
+       VERIFY_(status)
+       call MAPL_TimerOff(MAPL, gcnames(igc))
 
     enddo
 

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -850,6 +850,7 @@ contains
           VERIFY_(status)
        endif
 
+       ! Run the land model
        igc = LAND(i)
        call MAPL_TimerOn(MAPL, gcnames(igc))
        call ESMF_GridCompRun(gcs(igc), importState=gim(igc), exportState=gex(igc), clock=clock, phase=1, userRC=status)
@@ -858,6 +859,13 @@ contains
        VERIFY_(status)
        call MAPL_TimerOff(MAPL, gcnames(igc))
 
+       ! ApplyPrognPert - moved: now before calculating ensemble average that is picked up by HISTORY; reichle 24 May 2020 
+       igc = LANDPERT(i)
+       call MAPL_TimerOn(MAPL, gcnames(igc))
+       call ESMF_GridCompRun(gcs(igc), importState=gim(igc), exportState=gex(igc), clock=clock, phase=4, userRC=status)
+       VERIFY_(status)
+       call MAPL_TimerOff(MAPL, gcnames(igc))
+       
        ! Use land's output as the input to calculate the ensemble average
        if (LSM_CHOICE == 1) then
           ! collect cat_param 
@@ -872,16 +880,6 @@ contains
              VERIFY_(status)
           endif
        endif
-
-       ! Should this be moved to the beginning of the loop to avoid the pollution ?
-       ! THIS MUST BE MOVED AT LEAST TO BEFORE THE "ENSAVG/phase=3" CALL IF ENSEMBLE STATS OTHER THAN THE AVERAGE
-       ! ARE COMPUTED - reichle, 14 May 2020
-       ! ApplyPrognPert
-       igc = LANDPERT(i)
-       call MAPL_TimerOn(MAPL, gcnames(igc))
-       call ESMF_GridCompRun(gcs(igc), importState=gim(igc), exportState=gex(igc), clock=clock, phase=4, userRC=status)
-       VERIFY_(status)
-       call MAPL_TimerOff(MAPL, gcnames(igc))
 
     enddo
 

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -861,6 +861,13 @@ contains
        VERIFY_(status)
        call MAPL_TimerOff(MAPL, gcnames(igc))
 
+       ! ApplyPrognPert - moved: now before calculating ensemble average that is picked up by land analysis and HISTORY; reichle 28 May 2020 
+       igc = LANDPERT(i)
+       call MAPL_TimerOn(MAPL, gcnames(igc))
+       call ESMF_GridCompRun(gcs(igc), importState=gim(igc), exportState=gex(igc), clock=clock, phase=4, userRC=status)
+       VERIFY_(status)
+       call MAPL_TimerOff(MAPL, gcnames(igc))
+
        ! Use LAND's output as the input to calculate the ensemble average
        igc = LAND(i)
        if (LSM_CHOICE == 1) then
@@ -876,16 +883,6 @@ contains
              VERIFY_(status)
           endif
        endif
-
-       ! Should this be moved to the beginning of the loop to avoid the pollution ?
-       ! THIS MUST BE MOVED AT LEAST TO BEFORE THE "ENSAVG/phase=3" CALL IF ENSEMBLE STATS OTHER THAN THE AVERAGE
-       ! ARE COMPUTED - reichle, 14 May 2020
-       ! ApplyPrognPert
-       igc = LANDPERT(i)
-       call MAPL_TimerOn(MAPL, gcnames(igc))
-       call ESMF_GridCompRun(gcs(igc), importState=gim(igc), exportState=gex(igc), clock=clock, phase=4, userRC=status)
-       VERIFY_(status)
-       call MAPL_TimerOff(MAPL, gcnames(igc))
 
     enddo
 

--- a/src/Components/GEOSldas_GridComp/GEOSens_GridComp/GEOS_EnsGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSens_GridComp/GEOS_EnsGridComp.F90
@@ -8,8 +8,9 @@ module GEOS_EnsGridCompMod
   use ESMF
   use MAPL_Mod
   use lsm_routines, only: DZGT
-  use catch_types, ONLY: cat_progn_type
-  use catch_types, only: cat_param_type
+  use catch_types,  only: cat_progn_type
+  use catch_types,  only: cat_param_type
+
   use, intrinsic :: ieee_arithmetic
   
   implicit none
@@ -19,17 +20,18 @@ module GEOS_EnsGridCompMod
   public :: SetServices
   public :: catch_progn
   public :: catch_param
+
   ! !DESCRIPTION: This GridComp collect ensemble member and then averages the vaiables form catchment
 
   !EOP
-  integer :: NUM_ENSEMBLE
-  integer :: collect_land_counter
-  integer :: collect_force_counter
-  integer,parameter :: NUM_SUBTILES=4
-  real, parameter      :: daylen = 86400.
+  integer            :: NUM_ENSEMBLE
+  integer            :: collect_land_counter
+  integer            :: collect_force_counter
+  integer, parameter :: NUM_SUBTILES=4
+  real               :: enavg_nodata_threshold
 
   type(cat_progn_type),dimension(:,:), allocatable :: catch_progn
-  type(cat_param_type),dimension(:), allocatable :: catch_param
+  type(cat_param_type),dimension(:  ), allocatable :: catch_param
 
 
 contains
@@ -1719,6 +1721,10 @@ contains
     call MAPL_GetResource ( MAPL, NUM_ENSEMBLE, Label="NUM_LDAS_ENSEMBLE:", DEFAULT=1, RC=STATUS)
     VERIFY_(STATUS)
 
+    ! nodata handling for ensemble average
+    _ASSERT( (MAPL_UNDEF>.9999*1.e15), Iam // ': nodata handling for ensemble average requires MAPL_UNDEF to be a very large number') 
+    enavg_nodata_threshold   = MAPL_UNDEF/(NUM_ENSEMBLE+1)   
+
     collect_land_counter     = 0
     collect_force_counter    = 0
 
@@ -3321,7 +3327,30 @@ contains
         if(associated(SPLAND_enavg)) SPLAND_enavg = SPLAND_enavg/NUM_ENSEMBLE
         if(associated(SPWATR_enavg)) SPWATR_enavg = SPWATR_enavg/NUM_ENSEMBLE
         if(associated(SPSNOW_enavg)) SPSNOW_enavg = SPSNOW_enavg/NUM_ENSEMBLE
-    endif
+
+        ! Deal with no-data-values
+        !
+        ! Surface temperature components may be nodata in some but not all ensemble members.
+        !   (Nodata values are assigned in GEOS_CatchGridComp.F90 when the associated 
+        !    area fraction is zero.)
+        !
+        ! For now, the ensemble average is set to nodata if any member has a nodata value.
+        !
+        ! Alternatively, only ensemble members with good values could be averaged, or the 
+        !   averaging could use the associated area fraction as averaging weights.
+        !
+        ! The simple detection implemented here relies on MAPL_UNDEF being many orders of 
+        !   magnitude larger than any valid values, which works fine for Earth surface 
+        !   temperatures as long as MAPL_UNDEF is 1.e15.
+        !
+        ! - reichle, 29 May 2020
+                
+        if(associated(TPSNOW_enavg))  where (TPSNOW_enavg > enavg_nodata_threshold)  TPSNOW_enavg = MAPL_UNDEF
+        if(associated(TPSAT_enavg ))  where (TPSAT_enavg  > enavg_nodata_threshold)  TPSAT_enavg  = MAPL_UNDEF
+        if(associated(TPWLT_enavg ))  where (TPWLT_enavg  > enavg_nodata_threshold)  TPWLT_enavg  = MAPL_UNDEF
+        if(associated(TPUNST_enavg))  where (TPUNST_enavg > enavg_nodata_threshold)  TPUNST_enavg = MAPL_UNDEF
+
+     end if     ! collect_land_counter==NUM_ENSEMBLE
 
     ! Turn timers off
     call MAPL_TimerOff(MAPL, "Collect_land")

--- a/src/Components/GEOSldas_GridComp/GEOSens_GridComp/GEOS_EnsGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSens_GridComp/GEOS_EnsGridComp.F90
@@ -70,7 +70,7 @@ contains
          )
     VERIFY_(status)
 
-    ! phase one: collect ensembl forces
+    ! phase one: collect forcing ensemble 
     call MAPL_GridCompSetEntryPoint(                                            &
          gc,                                                                    &
          ESMF_METHOD_RUN,                                                       &

--- a/src/Components/GEOSldas_GridComp/GEOSens_GridComp/GEOS_EnsGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSens_GridComp/GEOS_EnsGridComp.F90
@@ -8,7 +8,6 @@ module GEOS_EnsGridCompMod
   use ESMF
   use MAPL_Mod
   use lsm_routines, only: DZGT
-  use LDAS_ensdrv_Globals, only: nodata_generic
   use catch_types, ONLY: cat_progn_type
   use catch_types, only: cat_param_type
   use, intrinsic :: ieee_arithmetic

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1166,12 +1166,8 @@ contains
           
           call MAPL_GetResource ( MAPL, GridName, Label="GEOSldas.GRIDNAME:", DEFAULT="EASE", RC=STATUS)
           _VERIFY(STATUS)
-          
-          _ASSERT( (NUM_ENSEMBLE>1),                                                      &
-               'out_smapL4SMaup=.true. only works for NUM_ENSEMBLE>1')
-          
-          _ASSERT( (index(GridName,"EASEv2-M09") /=0),                                    &
-               'out_smapL4SMaup=.true. only works with EASEv2-M09 tile space')
+          _ASSERT( (NUM_ENSEMBLE>1),                   "out_smapL4SMaup=.true. only works for NUM_ENSEMBLE>1")
+          _ASSERT( (index(GridName,"EASEv2-M09") /=0), "out_smapL4SMaup=.true. only works with EASEv2-M09 tile space")
           
        end if
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -2119,9 +2119,12 @@ contains
        TB_H_enavg(:)         = TB_H_enavg(:)/NUM_ENSEMBLE
        TB_V_enavg(:)         = TB_V_enavg(:)/NUM_ENSEMBLE
 
-       where (tb_nodata) TB_H_enavg = MAPL_UNDEF
-       where (tb_nodata) TB_V_enavg = MAPL_UNDEF
-
+       ! finalize no-data-value
+       where (tb_nodata)
+          TB_H_enavg = MAPL_UNDEF
+          TB_V_enavg = MAPL_UNDEF
+       end where
+       
     endif
     
     deallocate(Tb_h_tmp, Tb_v_tmp, sfmc_mwRTM, tsoil_mwRTM)

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -58,7 +58,7 @@ module GEOS_LandAssimGridCompMod
   use clsm_ensupd_enkf_update,   only: output_incr_etc
   use clsm_ensupd_enkf_update,   only: write_smapL4SMaup 
   use clsm_ensdrv_out_routines,  only: init_log, GEOS_output_smapL4SMlmc 
-  use mwRTM_routines,            only : mwRTM_get_Tb, catch2mwRTM_vars
+  use mwRTM_routines,            only: mwRTM_get_Tb, catch2mwRTM_vars
 
   use, intrinsic :: ieee_arithmetic    
 
@@ -1161,9 +1161,20 @@ contains
             out_smapL4SMaup,                         &
             N_obsbias_max                            &
             )
-       call MAPL_GetResource ( MAPL, GridName, Label="GEOSldas.GRIDNAME:", DEFAULT="EASE", RC=STATUS)
-       _VERIFY(STATUS)
-       if (index(GridName,"-CF") /=0) out_smapL4SMaup = .false. ! no out_smap for now if it is cs grid
+
+       if (out_smapL4SMaup) then
+          
+          call MAPL_GetResource ( MAPL, GridName, Label="GEOSldas.GRIDNAME:", DEFAULT="EASE", RC=STATUS)
+          _VERIFY(STATUS)
+          
+          _ASSERT( (NUM_ENSEMBLE>1),                                                      &
+               'out_smapL4SMaup=.true. only works for NUM_ENSEMBLE>1')
+          
+          _ASSERT( (index(GridName,"EASEv2-M09") /=0),                                    &
+               'out_smapL4SMaup=.true. only works with EASEv2-M09 tile space')
+          
+       end if
+
     endif
     
     call MPI_BCAST(mwRTM,                 1, MPI_LOGICAL,        0,MPICOMM,mpierr)

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -2119,9 +2119,9 @@ contains
        TB_H_enavg(:)         = TB_H_enavg(:)/NUM_ENSEMBLE
        TB_V_enavg(:)         = TB_V_enavg(:)/NUM_ENSEMBLE
 
-       TB_H_enavg(tb_nodata) = MAPL_UNDEF
-       TB_V_enavg(tb_nodata) = MAPL_UNDEF
-       
+       where (tb_nodata) TB_H_enavg = MAPL_UNDEF
+       where (tb_nodata) TB_V_enavg = MAPL_UNDEF
+
     endif
     
     deallocate(Tb_h_tmp, Tb_v_tmp, sfmc_mwRTM, tsoil_mwRTM)

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -111,6 +111,8 @@ module GEOS_LandAssimGridCompMod
 
 contains
   
+  ! ******************************************************************************
+
   !BOP
   ! !IROUTINE: SetServices -- Sets ESMF services for component
   ! !INTERFACE:
@@ -919,6 +921,8 @@ contains
     
   end subroutine SetServices
   
+  ! ******************************************************************************
+
   ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !BOP
   ! !IROTUINE: Initialize -- initialize method for LandAssim GC
@@ -1187,6 +1191,8 @@ contains
     
   end subroutine Initialize
   
+  ! ******************************************************************************
+
   ! !IROUTINE: RUN 
   ! !INTERFACE:
   subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
@@ -1789,6 +1795,8 @@ contains
     
   end subroutine RUN
   
+  ! ******************************************************************************
+
   ! !IROTUINE: collecting and averaging
   
   subroutine UPDATE_ASSIM(gc, import, export, clock, rc)
@@ -1940,6 +1948,7 @@ contains
     
   end subroutine UPDATE_ASSIM
   
+  ! ******************************************************************************
   
   ! subroutine to calculate Tb for HISTORY output
   
@@ -2055,7 +2064,7 @@ contains
          mwRTM_param%poros, &
          WCSF,              & 
          TPSURF,            & 
-         TP1-MAPL_TICE,     &    ! units deg C !!!
+         TP1,               &    ! units deg C !!!
          sfmc_mwRTM,        & 
          tsoil_mwRTM )        
     
@@ -2104,6 +2113,7 @@ contains
     RETURN_(_SUCCESS)
   end subroutine CALC_LAND_TB
   
+  ! ******************************************************************************
   
   subroutine read_pert_rseed(seed_fname,pert_rseed_r8)
     use netcdf
@@ -2138,6 +2148,8 @@ contains
     end subroutine check
   end subroutine read_pert_rseed
   
+  ! ******************************************************************************
+
   subroutine write_pert_rseed(chk_fname, pert_rseed_r8)
     use netcdf
     character(len=*),intent(in)        :: chk_fname
@@ -2185,6 +2197,7 @@ contains
     end subroutine check
   end subroutine write_pert_rseed
   
+  ! ******************************************************************************
   
   subroutine get_mwrtm_param(internal,N_catl, rc)
     type(ESMF_State),  intent(inout) :: INTERNAL
@@ -2289,6 +2302,8 @@ contains
     _RETURN(_SUCCESS)
   end subroutine get_mwrtm_param
   
+  ! ******************************************************************************
+
   !BOP
   ! !IROTUINE: Finalize -- finalize method for LDAS GC
   ! !INTERFACE:
@@ -2362,3 +2377,5 @@ contains
   end subroutine Finalize
 
 end module GEOS_LandAssimGridCompMod
+
+! ====================== EOF =======================================================

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_bias_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_bias_routines.F90
@@ -40,9 +40,6 @@ module clsm_bias_routines
   use LDAS_ensdrv_functions,            ONLY:     &
        get_io_filename
 
-  use LDAS_ensdrv_init_routines,        ONLY:     &
-       clsm_ensdrv_get_command_line
-
   use clsm_ensupd_upd_routines,         ONLY:     &
        get_cat_progn_ens_avg
 
@@ -78,78 +75,6 @@ contains
   !
   ! -------------------------------------------------------------------
   
-  subroutine clsm_cat_bias_get_command_line(                    &
-       cat_bias_inputs_path, cat_bias_inputs_file               &
-       )
-    
-    ! get some inputs from command line 
-    !
-    ! if present, command line arguments overwrite inputs from
-    ! catbias_inputs namelist files
-    !
-    ! command line should look something like
-    !
-    ! a.out -cat_bias_inputs_file fname.nml 
-    !
-    ! NOTE: This subroutine does NOT stop for unknown arguments!
-    !       (If that is desired, all arguments used by 
-    !        clsm_ensdrv_get_command_line() must be listed here
-    !        explicitly and be ignored.)
-    !
-    ! reichle, 18 Oct 2005
-    ! 
-    ! ----------------------------------------------------------------
-    
-    implicit none
-    
-    character(*), intent(inout), optional :: cat_bias_inputs_path
-    character(*),  intent(inout), optional :: cat_bias_inputs_file    
-    
-    ! -----------------------------------------------------------------
-    
-    integer :: N_args, iargc, i
-    
-    character(40) :: arg
-    
-    !external getarg, iargc
-    
-    ! -----------------------------------------------------------------
-    
-    N_args = iargc()
-    
-    i=0
-    
-    do while ( i < N_args )
-       
-       i = i+1
-       
-       call getarg(i,arg)
-       
-       if     ( trim(arg) == '-cat_bias_inputs_path' ) then
-          i = i+1
-          if (present(cat_bias_inputs_path))  &
-               call getarg(i,cat_bias_inputs_path)
-          
-       elseif ( trim(arg) == '-cat_bias_inputs_file' ) then
-          i = i+1
-          if (present(cat_bias_inputs_file))  &
-               call getarg(i,cat_bias_inputs_file)
-          
-       else
-               
-          i=i+1
-          if (logit) write (logunit,*)                                    &
-               'clsm_cat_bias_get_command_line(): IGNORING argument = ',  &
-               trim(arg)
-          
-       endif
-       
-    end do
-    
-  end subroutine clsm_cat_bias_get_command_line
-  
-  ! ********************************************************************
-
   subroutine io_rstrt_cat_bias( action, work_path, exp_id, date_time, &
        model_dtstep, N_cat, N_catbias, cat_bias )
     
@@ -578,7 +503,6 @@ contains
     ! read default cat bias inputs file
     
     cat_bias_inputs_path = './'                                       ! set default 
-    !call clsm_ensdrv_get_command_line(run_path=cat_bias_inputs_path)
     cat_bias_inputs_file = 'LDASsa_DEFAULT_inputs_catbias.nml'
       
     fname = trim(cat_bias_inputs_path) // '/' // trim(cat_bias_inputs_file)
@@ -594,21 +518,11 @@ contains
     close(10,status='keep')
     
        
-    ! Get name and path for special cat bias inputs file from
-    ! command line (if present) 
-    
-   ! cat_bias_inputs_path = ''
-   ! cat_bias_inputs_file = ''
-    
-   ! call clsm_cat_bias_get_command_line(                            &
-   !      cat_bias_inputs_path=cat_bias_inputs_path,                 &
-   !      cat_bias_inputs_file=cat_bias_inputs_file )
+    ! Read from special cat bias inputs file (if present) 
     
     cat_bias_inputs_file = 'LDASsa_SPECIAL_inputs_catbias.nml'
-   ! if ( trim(cat_bias_inputs_path) /= ''  .and.                &
-   !      trim(cat_bias_inputs_file) /= ''          ) then
-       
-       ! Read data from special cat bias inputs namelist file 
+
+    ! Read data from special cat bias inputs namelist file 
        
     fname = trim(cat_bias_inputs_path)//'/'//trim(cat_bias_inputs_file)
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensdrv_out_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensdrv_out_routines.F90
@@ -32,10 +32,6 @@ module clsm_ensdrv_out_routines
   use LDAS_DateTimeMod,                 ONLY:    &
        date_time_type
   
-  use LDAS_ensdrv_init_routines,        ONLY:     &
-       clsm_ensdrv_get_command_line,              &
-       add_domain_to_path
-
   use LDAS_ensdrv_functions,            ONLY:     &
        get_io_filename
        
@@ -120,52 +116,8 @@ contains
        
        if (logunit/=output_unit) then
           
-          ! get command line arguments
-          !
-          ! NOTE: If ldas_abort() is called from clsm_ensdrv_get_command_line() at this
-          !       time, the error message should appear in a file named "fort.[logunit]"
-          
-          call clsm_ensdrv_get_command_line(                 &
-               start_time=start_time,                        &
-               work_path=work_path, exp_domain=exp_domain,   &
-               exp_id=exp_id )         
-          
-          ! augment work_path (must be same as in read_driver_inputs() )
-          
-          io_path = add_domain_to_path( work_path, exp_domain )
-          
-          write (myid_string,'(i4.4)') myid
-          
-          dir_name = 'rc_out'
-          file_tag = 'ldas_log' 
-          file_ext = '.txt'
-          
-          if (.not. master_proc) then
-             
-             file_tag = trim(file_tag) // '_PE' // myid_string
-             
-          end if
-          
-          ! NOTE: If ldas_abort() is called from get_io_filename() at this time, 
-          !       the error message should appear in a file named "fort.[logunit]"      
-          
-          fname = get_io_filename( io_path, exp_id, file_tag, date_time=start_time, &
-               dir_name=dir_name, file_ext=file_ext )
-          
-          open (logunit, file=trim(fname), form='formatted', action='write',        &
-               status='new', iostat=istat)
-          
-          if (istat/=0) then
-             
-             ! this call to ldas_abort() should create a file named "fort.[logunit]"
-             
-             err_msg = 'ERROR opening log file (perhaps it already exists)'
-             call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
-             
-          end if
-          
-          write (logunit,*)
-          write (logunit,'(400A)') 'logfile: ' // trim(fname)
+          err_msg = 'logunit/=output_unit (stdout) - this should never happen per module LDAS_ensdrv_Globals'
+          call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
           
        else
           

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -1544,8 +1544,9 @@ contains
 
        deallocate(Observations_tmp)
 
-#endif  ! LDAS_MPI
-       ! reorder tilenum, so it is consisten with the order in tile_coord.bin file
+#endif ! LDAS_MPI
+       
+       ! reorder tilenum, so it is consistent with the order in tile_coord.bin file
        if(present(rf2f)) then
           allocate(rf_tilenums(N_obsf), tilenums(N_obsf))
           rf_tilenums = Observations_f(:)%tilenum
@@ -1553,6 +1554,7 @@ contains
           Observations_f(:)%tilenum =tilenums
           deallocate(rf_tilenums, tilenums)
        endif
+       
        ! write to file
 
        fname = get_io_filename( './', exp_id, file_tag, date_time=date_time, &
@@ -1604,8 +1606,8 @@ contains
 
   ! **********************************************************************
 
-  subroutine output_incr_etc( out_ObsFcstAna,               &
-       date_time, work_path, exp_id,                        &
+  subroutine output_incr_etc( out_ObsFcstAna,                                &
+       date_time, work_path, exp_id,                                         &
        N_obsl, N_obs_param, N_ens,                                           &
        N_catl, tile_coord_l,                                                 &
        N_catf, tile_coord_f, tile_grid_f, tile_grid_g,                       &

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -41,9 +41,6 @@ module clsm_ensupd_upd_routines
        get_io_filename,                           &
        is_in_rectangle
 
-  use LDAS_ensdrv_init_routines,        ONLY:     &
-       clsm_ensdrv_get_command_line
-  
   use LDAS_DateTimeMod,                 ONLY:     &
        date_time_type
   
@@ -190,9 +187,6 @@ contains
     !      specified at the command line using -ens_upd_inputs_path 
     !      and -ens_upd_inputs_file
     !
-    ! 3.) overwrite options from command line (if present)
-    !      see subroutine clsm_ensupd_get_command_line()
-    !
     ! reichle, 19 Jul 2005 
     ! reichle, 14 Apr 2006 - added "update_type" to namelist and outputs
     !                      - removed reading from "stored"/"saved" nml file
@@ -284,7 +278,6 @@ contains
     ! Set default file name for EnKF inputs namelist file
     
     ens_upd_inputs_path = '.'                                       ! set default 
-    !call clsm_ensdrv_get_command_line(run_path=ens_upd_inputs_path)
     ens_upd_inputs_file = 'LDASsa_DEFAULT_inputs_ensupd.nml'
     
     ! Read data from default ens_upd_inputs namelist file 
@@ -308,14 +301,7 @@ contains
     ens_upd_inputs_path = '.'
     ens_upd_inputs_file = 'LDASsa_SPECIAL_inputs_ensupd.nml'
        
-   ! call clsm_ensupd_get_command_line(                              &
-   !      ens_upd_inputs_path=ens_upd_inputs_path,                 &
-   !      ens_upd_inputs_file=ens_upd_inputs_file )
-    
-   ! if ( trim(ens_upd_inputs_path) /= ''  .and.            &
-   !      trim(ens_upd_inputs_file) /= ''          ) then
-       
-       ! Read data from special EnKF inputs namelist file 
+    ! Read data from special EnKF inputs namelist file 
        
     fname = trim(ens_upd_inputs_path)//'/'//trim(ens_upd_inputs_file)
     inquire(file=fname, exist=file_exists)
@@ -689,78 +675,6 @@ contains
     
   end subroutine read_ens_upd_inputs
   
-  ! ***********************************************************************
-  
-  subroutine clsm_ensupd_get_command_line(                            &
-       ens_upd_inputs_path, ens_upd_inputs_file                       &
-       )
-    
-    ! get some inputs from command line 
-    !
-    ! if present, command line arguments overwrite inputs from
-    ! ens_upd_inputs namelist files
-    !
-    ! command line should look something like
-    !
-    ! a.out -upd_driver_inputs_file fname.nml 
-    !
-    ! NOTE: This subroutine does NOT stop for unknown arguments!
-    !       (If that is desired, all arguments used by 
-    !        clsm_ensdrv_get_command_line() must be listed here
-    !        explicitly and be ignored.)
-    !
-    ! reichle, 19 Jul 2005
-    ! reichle,  2 Aug 2005 - consistency with clsm_ensdrv_get_command_line()
-    ! 
-    ! ----------------------------------------------------------------
-    
-    implicit none
-    
-    character(*), intent(inout), optional :: ens_upd_inputs_path
-    character(*),  intent(inout), optional :: ens_upd_inputs_file    
-    
-    ! -----------------------------------------------------------------
-    
-    integer :: N_args, iargc, i
-    
-    character(40) :: arg
-    
-    !external getarg, iargc
-    
-    ! -----------------------------------------------------------------
-    
-    N_args = iargc()
-    
-    i=0
-    
-    do while ( i < N_args )
-       
-       i = i+1
-       
-       call getarg(i,arg)
-       
-       if     ( trim(arg) == '-ens_upd_inputs_path' ) then
-          i = i+1
-          if (present(ens_upd_inputs_path))  &
-               call getarg(i,ens_upd_inputs_path)
-          
-       elseif ( trim(arg) == '-ens_upd_inputs_file' ) then
-          i = i+1
-          if (present(ens_upd_inputs_file))  &
-               call getarg(i,ens_upd_inputs_file)
-          
-       else
-               
-          i=i+1
-          if (logit) write (logunit,*) &
-               'clsm_ensupd_get_command_line(): IGNORING argument = ', trim(arg)
-          
-       endif
-       
-    end do
-    
-  end subroutine clsm_ensupd_get_command_line
-
   ! ********************************************************************
 
   subroutine init_obslog( work_path, exp_id, date_time )

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -534,10 +534,21 @@ contains
        
     end if
 
-    ! when L4SMaup files are written, ensure that species of interest do not
-    ! simultaneously include "SMAP_L*_Tb*" and "SMOS_fit_Tb*" obs
+    ! when L4SMaup files are written, ensure that N_ens>1 and that species of interest
+    ! do not simultaneously include "SMAP_L*_Tb*" and "SMOS_fit_Tb*" obs
     
     if (out_smapL4SMaup) then
+
+       ! stop if N_ens<=1 (cannot compute ensemble std-dev)
+       
+       if (N_ens<=1) then
+          
+          err_msg = 'out_smapL4SMaup=.true. is *not* compatible with N_ens<=1'
+          call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
+          
+       end if
+
+       ! find out if SMAP and SMOS species are simultaneously present
        
        smap_species = .false.
        smos_species = .false.

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -534,21 +534,10 @@ contains
        
     end if
 
-    ! when L4SMaup files are written, ensure that N_ens>1 and that species of interest
-    ! do not simultaneously include "SMAP_L*_Tb*" and "SMOS_fit_Tb*" obs
+    ! when L4SMaup files are written, ensure that species of interest do not
+    ! simultaneously include "SMAP_L*_Tb*" and "SMOS_fit_Tb*" obs
     
     if (out_smapL4SMaup) then
-
-       ! stop if N_ens<=1 (cannot compute ensemble std-dev)
-       
-       if (N_ens<=1) then
-          
-          err_msg = 'out_smapL4SMaup=.true. is *not* compatible with N_ens<=1'
-          call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
-          
-       end if
-
-       ! find out if SMAP and SMOS species are simultaneously present
        
        smap_species = .false.
        smos_species = .false.

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_routines.F90
@@ -320,7 +320,7 @@ contains
     
     !---------------------------------------------------
     
-    if (logit) write(logunit,*) 'entering mwRTM_get_Tb...'
+    !if (logit) write(logunit,*) 'entering mwRTM_get_Tb...'
 
     ! check first element of elevation against no-data-value
     ! (elevation is needed only when incl_atm_terms=.true.)
@@ -495,7 +495,7 @@ contains
 
     end do
     
-    if (logit) write(logunit,*) 'exiting mwRTM_get_Tb.'
+    !if (logit) write(logunit,*) 'exiting mwRTM_get_Tb.'
     
   end subroutine mwRTM_get_Tb
   

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_routines.F90
@@ -28,7 +28,7 @@ module mwRTM_routines
        mwRTM_param_nodata_check,                  &
        assignment (=)
     
-  use LDAS_ensdrv_globals,           ONLY:     &
+  use LDAS_ensdrv_globals,              ONLY:     &
        logit,                                     &
        logunit,                                   &
        nodata_generic,                            &
@@ -37,7 +37,7 @@ module mwRTM_routines
   use LDAS_ensdrv_functions,            ONLY:     &
        open_land_param_file
 
-  use LDAS_exceptionsMod,                  ONLY:     &
+  use LDAS_exceptionsMod,               ONLY:     &
        ldas_abort,                                &
        LDAS_GENERIC_ERROR
 
@@ -103,7 +103,7 @@ contains
     
     character(100), dimension(N_search_dir_max) :: search_dir
 
-    logical                                     :: all_nodata, is_nodata
+    logical                                     :: all_nodata, mwp_nodata
     
     character(len=*), parameter :: Iam = 'mwRTM_get_param'
     character(len=400) :: err_msg
@@ -156,9 +156,9 @@ contains
     
     do n=1,N_tile
        
-       call mwRTM_param_nodata_check( mwp(n), is_nodata )
+       call mwRTM_param_nodata_check( mwp(n), mwp_nodata )
        
-       if (.not. is_nodata) all_nodata = .false.
+       if (.not. mwp_nodata) all_nodata = .false.
        
     end do
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_types.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_types.F90
@@ -14,12 +14,12 @@ module mwRTM_types
   ! --------------------------------------------------------------------------
   
   use LDAS_ensdrv_globals,           ONLY:     &
-       nodata_generic,                            &
-       nodata_tol_generic,    &
-       is_nodata
+       nodata_generic,                         &
+       nodata_tol_generic,                     &
+       LDAS_is_nodata
 
-  use ldas_exceptionsMod,                  ONLY:     &
-       ldas_abort,                                &
+  use ldas_exceptionsMod,            ONLY:     &
+       ldas_abort,                             &
        LDAS_GENERIC_ERROR
 
   implicit none
@@ -277,13 +277,13 @@ contains
 
   ! ************************************************************
   
-  subroutine mwRTM_param_nodata_check( mwp, nodata )
+  subroutine mwRTM_param_nodata_check( mwp, mwp_nodata )
     
     implicit none
     
     type(mwRTM_param_type), intent(inout) :: mwp
     
-    logical,                intent(  out) :: nodata
+    logical,                intent(  out) :: mwp_nodata
     
     ! local variables
     
@@ -294,32 +294,32 @@ contains
     realvegcls  = real(mwp%vegcls)
     realsoilcls = real(mwp%soilcls)
     
-    if ( is_nodata (realvegcls    ) .or.        &
-         is_nodata (realsoilcls   ) .or.        &
-         is_nodata (mwp%sand      ) .or.        &
-         is_nodata (mwp%clay      ) .or.        &
-         is_nodata (mwp%poros     ) .or.        &
-         is_nodata (mwp%wang_wt   ) .or.        &
-         is_nodata (mwp%wang_wp   ) .or.        &
-         is_nodata (mwp%rgh_hmin  ) .or.        &
-         is_nodata (mwp%rgh_hmax  ) .or.        &
-         is_nodata (mwp%rgh_wmin  ) .or.        &
-         is_nodata (mwp%rgh_wmax  ) .or.        &
-         is_nodata (mwp%rgh_Nrh   ) .or.        &
-         is_nodata (mwp%rgh_Nrv   ) .or.        &
-         is_nodata (mwp%rgh_polmix) .or.        &
-         is_nodata (mwp%omega     ) .or.        &
-         is_nodata (mwp%bh        ) .or.        &
-         is_nodata (mwp%bv        ) .or.        &
-         is_nodata (mwp%lewt      )      ) then
+    if ( LDAS_is_nodata( realvegcls     ) .or.        &
+         LDAS_is_nodata( realsoilcls    ) .or.        &
+         LDAS_is_nodata( mwp%sand       ) .or.        &
+         LDAS_is_nodata( mwp%clay       ) .or.        &
+         LDAS_is_nodata( mwp%poros      ) .or.        &
+         LDAS_is_nodata( mwp%wang_wt    ) .or.        &
+         LDAS_is_nodata( mwp%wang_wp    ) .or.        &
+         LDAS_is_nodata( mwp%rgh_hmin   ) .or.        &
+         LDAS_is_nodata( mwp%rgh_hmax   ) .or.        &
+         LDAS_is_nodata( mwp%rgh_wmin   ) .or.        &
+         LDAS_is_nodata( mwp%rgh_wmax   ) .or.        &
+         LDAS_is_nodata( mwp%rgh_Nrh    ) .or.        &
+         LDAS_is_nodata( mwp%rgh_Nrv    ) .or.        &
+         LDAS_is_nodata( mwp%rgh_polmix ) .or.        &
+         LDAS_is_nodata( mwp%omega      ) .or.        &
+         LDAS_is_nodata( mwp%bh         ) .or.        &
+         LDAS_is_nodata( mwp%bv         ) .or.        &
+         LDAS_is_nodata( mwp%lewt       )      ) then
        
-       mwp = nodata_generic
+       mwp        = nodata_generic
        
-       nodata = .true.
+       mwp_nodata = .true.
 
     else
        
-       nodata = .false.
+       mwp_nodata = .false.
        
     end if
     

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_types.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_types.F90
@@ -15,7 +15,8 @@ module mwRTM_types
   
   use LDAS_ensdrv_globals,           ONLY:     &
        nodata_generic,                            &
-       nodata_tol_generic
+       nodata_tol_generic,    &
+       is_nodata
 
   use ldas_exceptionsMod,                  ONLY:     &
        ldas_abort,                                &
@@ -276,13 +277,13 @@ contains
 
   ! ************************************************************
   
-  subroutine mwRTM_param_nodata_check( mwp, is_nodata )
+  subroutine mwRTM_param_nodata_check( mwp, nodata )
     
     implicit none
     
     type(mwRTM_param_type), intent(inout) :: mwp
     
-    logical,                intent(  out) :: is_nodata
+    logical,                intent(  out) :: nodata
     
     ! local variables
     
@@ -293,32 +294,32 @@ contains
     realvegcls  = real(mwp%vegcls)
     realsoilcls = real(mwp%soilcls)
     
-    if ( (abs(realvegcls    -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(realsoilcls   -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%sand      -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%clay      -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%poros     -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%wang_wt   -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%wang_wp   -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%rgh_hmin  -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%rgh_hmax  -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%rgh_wmin  -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%rgh_wmax  -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%rgh_Nrh   -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%rgh_Nrv   -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%rgh_polmix-nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%omega     -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%bh        -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%bv        -nodata_generic)<nodata_tol_generic) .or.        &
-         (abs(mwp%lewt      -nodata_generic)<nodata_tol_generic)      ) then
+    if ( is_nodata (realvegcls    ) .or.        &
+         is_nodata (realsoilcls   ) .or.        &
+         is_nodata (mwp%sand      ) .or.        &
+         is_nodata (mwp%clay      ) .or.        &
+         is_nodata (mwp%poros     ) .or.        &
+         is_nodata (mwp%wang_wt   ) .or.        &
+         is_nodata (mwp%wang_wp   ) .or.        &
+         is_nodata (mwp%rgh_hmin  ) .or.        &
+         is_nodata (mwp%rgh_hmax  ) .or.        &
+         is_nodata (mwp%rgh_wmin  ) .or.        &
+         is_nodata (mwp%rgh_wmax  ) .or.        &
+         is_nodata (mwp%rgh_Nrh   ) .or.        &
+         is_nodata (mwp%rgh_Nrv   ) .or.        &
+         is_nodata (mwp%rgh_polmix) .or.        &
+         is_nodata (mwp%omega     ) .or.        &
+         is_nodata (mwp%bh        ) .or.        &
+         is_nodata (mwp%bv        ) .or.        &
+         is_nodata (mwp%lewt      )      ) then
        
        mwp = nodata_generic
        
-       is_nodata = .true.
+       nodata = .true.
 
     else
        
-       is_nodata = .false.
+       nodata = .false.
        
     end if
     

--- a/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/LDAS_PertRoutines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/LDAS_PertRoutines.F90
@@ -96,12 +96,6 @@ module LDAS_PertRoutinesMod
   use RepairForcingMod,                 ONLY:     &
        repair_forcing
 
-  ! CHANGED: Getting rid of command  line arguments
-  ! TODO: Check
-  ! use clsm_ensdrv_init_routines,        ONLY:     &
-  !      clsm_ensdrv_get_command_line,              &
-  !      add_domain_to_path
-
   use LDAS_ExceptionsMod,               ONLY:     &
        ldas_abort,                                &
        LDAS_GENERIC_ERROR
@@ -186,9 +180,6 @@ contains
     ! 2.) overwrite options from special namelist file (if present)
     !      specified at the command line using -ens_prop_inputs_path
     !      and -ens_prop_inputs_file
-    !
-    ! 3.) overwrite options from command line (if present)
-    !      see subroutine clsm_ensdrv_get_command_line()
     !
     ! reichle, 29 Mar 2004
     ! reichle, 31 Aug 2004 - added tskin_isccp
@@ -358,8 +349,6 @@ contains
     ! Set default file name for ens prop inputs namelist file
 
     ens_prop_inputs_path = './'                                       ! set default
-    ! CHANGED: commented out get_command_line
-    ! call clsm_ensdrv_get_command_line(run_path=ens_prop_inputs_path)
     ens_prop_inputs_file = 'LDASsa_DEFAULT_inputs_ensprop.nml'
 
     ! Read data from default ens_prop_inputs namelist file

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -3173,7 +3173,7 @@ contains
                 do k=1,N_catd
 
                    if ( abs(force_array(k,GEOSgcm_var) -nodata_GEOSgcm)<tol .or.          & 
-                        abs(ptrShForce(i1(k),j1(k))      -nodata_GEOSgcm)<tol      ) then
+                        abs(ptrShForce(i1(k),j1(k))    -nodata_GEOSgcm)<tol      ) then
                       
                       force_array(k,GEOSgcm_var) = nodata_GEOSgcm
 
@@ -3190,7 +3190,7 @@ contains
 
                 do k=1,N_catd
                    if ( abs(force_array(k,GEOSgcm_var)-nodata_GEOSgcm)<tol .or.          & 
-                        abs(ptrShForce(i1(k),j1(k))     -nodata_GEOSgcm)<tol       ) then
+                        abs(ptrShForce(i1(k),j1(k))   -nodata_GEOSgcm)<tol       ) then
                       force_array(k,GEOSgcm_var) = nodata_GEOSgcm
                    else                
                       this_lon = tile_coord(k)%com_lon

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_RepairForcing.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_RepairForcing.F90
@@ -4,7 +4,7 @@ module RepairForcingMod
   use LDAS_TileCoordType, only: tile_coord_type
   use LDAS_ExceptionsMod, only: ldas_abort, LDAS_GENERIC_ERROR
   use MAPL_SatVaporMod, only: MAPL_EQsat
-  use LDAS_ensdrv_Globals, only: logunit, is_nodata, nodata_generic, nodata_tol_generic
+  use LDAS_ensdrv_Globals, only: logunit, LDAS_is_nodata
   use MAPL_ConstantsMod, only: stefan_boltzmann=>MAPL_STFBOL
   use LDAS_ensdrv_Globals, only: master_logit
   implicit none
@@ -447,7 +447,7 @@ contains
 
        ! SWnet is no-data-value for most forcing data sets (except MERRA, G5DAS)
 
-       if( .not. is_nodata(met_force(i)%SWnet) ) then
+       if( .not. LDAS_is_nodata(met_force(i)%SWnet) ) then
 
           if (field(1:3)=='all' .or. field(1:7)=='SWnet  ') then
 
@@ -491,7 +491,7 @@ contains
 
        ! PARdffs is no-data-value for most forcing data sets (except MERRA, G5DAS)
 
-       if( .not. is_nodata(met_force(i)%PARdffs)) then
+       if( .not. LDAS_is_nodata(met_force(i)%PARdffs)) then
 
           if (field(1:3)=='all' .or. field(1:7)=='PARdffs') then
 
@@ -544,7 +544,7 @@ contains
        !
        ! MUST "repair" PARdffs *before* PARdrct
 
-       if( .not. is_nodata(met_force(i)%PARdrct) ) then
+       if( .not. LDAS_is_nodata(met_force(i)%PARdrct) ) then
 
           if (field(1:3)=='all' .or. field(1:7)=='PARdrct') then
 

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_RepairForcing.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_RepairForcing.F90
@@ -4,7 +4,7 @@ module RepairForcingMod
   use LDAS_TileCoordType, only: tile_coord_type
   use LDAS_ExceptionsMod, only: ldas_abort, LDAS_GENERIC_ERROR
   use MAPL_SatVaporMod, only: MAPL_EQsat
-  use LDAS_ensdrv_Globals, only: logunit, nodata_generic, nodata_tol_generic
+  use LDAS_ensdrv_Globals, only: logunit, is_nodata, nodata_generic, nodata_tol_generic
   use MAPL_ConstantsMod, only: stefan_boltzmann=>MAPL_STFBOL
   use LDAS_ensdrv_Globals, only: master_logit
   implicit none
@@ -447,7 +447,7 @@ contains
 
        ! SWnet is no-data-value for most forcing data sets (except MERRA, G5DAS)
 
-       if(abs(met_force(i)%SWnet-nodata_generic)>nodata_tol_generic) then
+       if( .not. is_nodata(met_force(i)%SWnet) ) then
 
           if (field(1:3)=='all' .or. field(1:7)=='SWnet  ') then
 
@@ -491,7 +491,7 @@ contains
 
        ! PARdffs is no-data-value for most forcing data sets (except MERRA, G5DAS)
 
-       if(abs(met_force(i)%PARdffs-nodata_generic)>nodata_tol_generic) then
+       if( .not. is_nodata(met_force(i)%PARdffs)) then
 
           if (field(1:3)=='all' .or. field(1:7)=='PARdffs') then
 
@@ -544,7 +544,7 @@ contains
        !
        ! MUST "repair" PARdffs *before* PARdrct
 
-       if(abs(met_force(i)%PARdrct-nodata_generic)>nodata_tol_generic) then
+       if( .not. is_nodata(met_force(i)%PARdrct) ) then
 
           if (field(1:3)=='all' .or. field(1:7)=='PARdrct') then
 

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_Globals.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_Globals.F90
@@ -20,6 +20,7 @@ module LDAS_ensdrv_Globals
   public :: nodata_generic
   public :: nodata_tolfrac_generic
   public :: nodata_tol_generic
+  public :: is_nodata
   public :: logunit
   public :: logit
   public :: master_logit
@@ -34,9 +35,11 @@ module LDAS_ensdrv_Globals
   
   real, parameter :: nodata_generic         = -9999.
   real, parameter :: nodata_tolfrac_generic = 1.e-4
-  
   real :: nodata_tol_generic = abs(nodata_generic*nodata_tolfrac_generic)
-  
+  real, parameter :: MAPL_UNDEF  = 1.0e15 ! private for now, no conflict with the one in MAPL   
+  real, parameter :: MAPL_UNDEF_tolfrac = 1.e-15
+  real :: MAPL_tol_generic = abs(MAPL_UNDEF*MAPL_UNDEF_tolfrac) 
+
   ! ----------------------------------------------------------------
   !
   ! log file
@@ -124,6 +127,18 @@ contains
     
   end subroutine write_status
 
+  elemental   function is_nodata(data) result(no_data)
+     real, intent(in) :: data
+     logical :: no_data
+
+     no_data = .false.
+     if (abs(data-nodata_generic) < nodata_tol_generic) then
+        no_data =.true.
+     else if ( abs(data-MAPL_UNDEF) < MAPL_tol_generic) then
+        no_data = .true.
+     endif
+
+  end function
   ! *************************************************************
   
 end module LDAS_ensdrv_Globals

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_init_routines.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_init_routines.F90
@@ -8,34 +8,28 @@ module LDAS_ensdrv_init_routines
   ! (originally in clsm_ensdrv_drv_routines.F90)
   !
   ! reichle, 22 Aug 2014
+  ! reichle, 22 May 2020 - cleanup
 
   use ESMF
   use GEOS_MOD
 
-  use LDAS_ensdrv_Globals,           ONLY:     &
+  use LDAS_ensdrv_Globals,              ONLY:     &
        log_master_only,                           &
        logunit,                                   &
        logit,                                     &
        nodata_generic
        
-  use MAPL_ConstantsMod,                ONLY:     &
-       Tzero  => MAPL_TICE
-
   use MAPL_BaseMod,                     ONLY:     &
        NTYPS  => MAPL_NumVegTypes
 
-  use LDAS_TileCoordType,                 ONLY:     &
+  use LDAS_TileCoordType,               ONLY:     &
        tile_coord_type,                           &
        grid_def_type,                             &
-       operator (==),                              &
+       operator (==),                             &
        N_cont_max,                                &
        io_tile_coord_type,                        &
        io_grid_def_type
   
-  use LDAS_DateTimeMod,                   ONLY:     &
-       date_time_type,                            &
-       get_dofyr_pentad
-
   use LDAS_ensdrv_functions,            ONLY:     &
        get_io_filename,                           &
        is_in_list,                                &
@@ -43,16 +37,12 @@ module LDAS_ensdrv_init_routines
        open_land_param_file,                      &
        word_count
        
-!  use clsm_ensdrv_drv_routines,         ONLY:     &
-!       check_cat_progn
-
-  use LDAS_TileCoordRoutines,              ONLY:     & 
+  use LDAS_TileCoordRoutines,           ONLY:     & 
        is_cat_in_box,                             &
-       !reorder_tiles,                             &
        get_tile_grid,                             &
        read_til_file
   
-  use LDAS_ExceptionsMod,                  ONLY:     &
+  use LDAS_ExceptionsMod,               ONLY:     &
        ldas_abort,                                &
        LDAS_GENERIC_ERROR
 
@@ -72,13 +62,9 @@ module LDAS_ensdrv_init_routines
 
   private
  
-  public :: add_domain_to_path
   public :: domain_setup
   public :: read_cat_param
-  public :: clsm_ensdrv_get_command_line
   public :: io_domain_files
-
-  !integer ,parameter :: N_gt=6, N_snow=3
 
   character(10), private :: tmpstring10
   character(40), private :: tmpstring40
@@ -86,24 +72,6 @@ module LDAS_ensdrv_init_routines
 contains
   
   ! ********************************************************************
-
-
-  character(200) function add_domain_to_path( pathname, exp_domain )
-    
-    ! make sure "exp_domain" is always added to "pathname" in the same way
-    ! (so that comparison of strings does not depend on extra slashes)
-    ! - reichle, 2 Apr 2014
-    
-    implicit none
-    
-    character(200) :: pathname
-    character(40)  :: exp_domain
-    
-    add_domain_to_path = trim(pathname)  // '/' // trim(exp_domain) // '/'
-    
-  end function add_domain_to_path
-    
-  ! ****************************************************************
   
   subroutine domain_setup(                                             &
        N_cat_global, tile_coord_global,                                &
@@ -1135,150 +1103,6 @@ contains
   end subroutine read_cat_param
 
   ! *************************************************************************
-
-  subroutine read_VEG_Height(                                                    &
-       N_catg, veg_path, V_HEIGHT )
-
-    ! addapted from read_cat_param
-
-    implicit none
-    
-    integer,                                    intent(in)  :: N_catg
-    character(*),                             intent(in)  :: veg_path
-    real, dimension(N_catg),intent(inout) :: V_HEIGHT
-       
-    character( 80) :: fname
-    character(999) :: tmpstr999
-    
-    character(100), dimension(2) :: search_dir
-
-    integer :: n, k, m, dummy_int, dummy_int2, istat, N_search_dir, N_col
-    
-    integer, dimension(N_catg)           :: tmpint, tmpint2, tmptileid
-    
-    real,    dimension(N_catg,7) :: tmpreal
-    
-    real    :: dummy_real, dummy_real2, z_in_m, term1, term2
-
-    logical :: dummy_logical
-
-    character(len=*), parameter          :: Iam = 'read_Veg_Hight'
-    character(len=400)                   :: err_msg
-
-    real,    dimension(NTYPS)            :: VGZ2
-
-    ! legacy vegetation height look-up table (for backward compatibility)
-    !
-    DATA VGZ2 /35.0, 20.0, 17.0, 0.6, 0.5, 0.6/      ! Dorman and Sellers (1989)
-    
-    ! ---------------------------------------------------------------------
-    
-    if (logit) write (logunit,*) 'reading VEG_HEIGHT'
-    if (logit) write (logunit,*)
-    
-    ! -----------------------------
-    
-    ! Vegetation class
-
-    if (logit) write (logunit,*) 'Reading vegetation class and, if available, height'
-    
-    fname = '/mosaic_veg_typs_fracs'
-
-    N_search_dir = 2         ! specify sub-dirs of veg_path to search for file "fname"
-    
-    search_dir(1) = 'clsm'
-    search_dir(2) = 'VEGETATION-GSWP2'
-
-    ! find out how many columns are in the (formatted) file
-    
-    istat = open_land_param_file(                                                 &
-         10, .true., dummy_logical, N_search_dir, fname, veg_path, search_dir)
-        
-    read(10,'(a)') tmpstr999    ! read first line
-    ! count words in first line (delimited by space)
-    N_col = word_count( tmpstr999 )
-
-    ! get line number or the real N_catg
-    n =1
-    do while (.true.) 
-       read(10,*,iostat= istat) tmpstr999
-       if(IS_IOSTAT_END(istat)) exit
-       n=n+1  
-    enddo
-
-    if(n /= N_catg) stop " Please don't add vegheight to REGIONAOL veg restart"
-
-    close(10, status='keep')
-    
-    
-    ! read parameters
-
-    istat = open_land_param_file(                                                 &
-         10, .true., dummy_logical, N_search_dir, fname, veg_path, search_dir)
-
-    tmptileid = 0
-
-    tmpreal   = nodata_generic
-    
-    select case (N_col)
-       
-    case (6)
-
-       ! legacy vegetation height from look-up table
-       
-       if (logit) write (logunit,*) 'Using vegetation height look-up table'
-
-       do n=1,N_catg
-          
-          read (10,*) tmptileid(n), dummy_int, tmpint(n)
-          
-       end do
-
-       if ( (any(tmpint<1)) .or. (any(tmpint>NTYPS)) ) then
-          
-          err_msg = 'veg type (class) exceeds allowed min/max'
-          call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
-          
-       end if
-       
-       do n=1,N_catg
-
-          tmpreal(n,1) = VGZ2( tmpint(n) )
-
-       end do
-
-    case (7)
-
-       ! vegetation height from boundary condition file
-       
-       if (logit) write (logunit,*) 'reading vegetation height from file'
-
-       do n=1,N_catg
-          
-          ! 7-th column contains veg height in m
-          
-          read (10,*) tmptileid(n), dummy_int, tmpint(n),         &
-               dummy_int2, dummy_real, dummy_real2, tmpreal(n,1)
-          
-       end do
-       
-    case default
-       
-       err_msg = 'unknown number of columns in ' // trim(fname)
-       call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
-       
-    end select
-    
-    close (10,status='keep')
-    
-    if (logit) write (logunit,*) 'done reading'
-    if (logit) write (logunit,*) 
-    
-    V_HEIGHT = tmpreal(:,1)
-      
-  end subroutine read_VEG_Height
-  
-  ! **********************************************************************
   
   subroutine read_black_or_whitelist(N_cat, fname, blacklist, N_black) 
     
@@ -1376,336 +1200,6 @@ contains
        
   end subroutine read_black_or_whitelist
   
-  ! ****************************************************************
-  
-  subroutine clsm_ensdrv_get_command_line(   &
-       driver_inputs_path,      &
-       driver_inputs_file,      &
-       start_time,              &
-       end_time,                &
-       resolution,              &
-       exp_domain,              &
-       exp_id,                  &
-       work_path,               &
-       run_path,                &
-       restart_path,            &
-       restart_domain,          &
-       restart_id,              &
-       tile_coord_path,         &
-       tile_coord_file,         &
-       catchment_def_path,      &
-       catchment_def_file,      &
-       met_tag,                 &
-       met_path,                &
-       force_dtstep,            &
-       restart,                 &
-       spin,                    &
-       ens_prop_inputs_path,    &
-       ens_prop_inputs_file,    &
-       N_ens,                   &
-       first_ens_id             &
-       )
-    
-    ! get inputs from command line 
-    !
-    ! if present, command line arguments overwrite inputs from
-    !  driver_inputs or ens_prop_inputs namelist files
-    !
-    ! command line should look something like
-    !
-    ! a.out -start_year 1979 -restart true -driver_inputs_file fname.nml 
-    !
-    ! NOTE: Arguments that are used for assimilation ("ensupd") must be 
-    !       listed here explicitly (and will be ignored).  Otherwise it
-    !       would not be possible to stop for unknown arguments.
-    !
-    ! reichle, 29 Aug 02
-    ! 
-    ! modified for namelist input file path and name
-    ! - reichle, 6 May 03
-    ! converted to optional arguments, added arguments for EnKF inputs
-    ! - reichle, 29 Mar 04
-    !
-    ! reichle,  2 Aug 2005 - consistency with clsm_ensdrv_get_command_line()
-    ! reichle,  6 Mar 2008 - added force_dtstep for DAS/MERRA integration
-    !
-    ! ----------------------------------------------------------------
-    
-    implicit none
-    
-    character(200), intent(inout), optional :: driver_inputs_path
-    character(200), intent(inout), optional :: work_path, run_path
-    character(200), intent(inout), optional :: restart_path
-    
-    character(40), intent(inout),  optional :: driver_inputs_file    
-    
-    type(date_time_type), intent(inout), optional :: start_time
-    type(date_time_type), intent(inout), optional :: end_time
-    
-    character(40), intent(inout), optional :: exp_domain, exp_id, resolution
-    character(40), intent(inout), optional :: restart_domain, restart_id
-
-    character(200), intent(inout), optional :: tile_coord_path
-    character(200), intent(inout), optional :: catchment_def_path
-    character(80),  intent(inout), optional :: tile_coord_file
-    character(40),  intent(inout), optional :: catchment_def_file
-    
-    character(200), intent(inout), optional :: met_path
-    character(80),  intent(inout), optional :: met_tag
-    
-    integer,        intent(inout), optional :: force_dtstep
-
-    logical,        intent(inout), optional :: restart, spin 
-    
-    character(200), intent(inout), optional :: ens_prop_inputs_path
-    character(40),  intent(inout), optional :: ens_prop_inputs_file    
-    
-    integer, intent(inout), optional :: N_ens, first_ens_id
-
-    ! -----------------------------------------------------------------
-    
-    integer :: N_args, iargc, i
-    
-    character(40) :: arg
-
-    logical :: outlog
-    
-    character(len=*), parameter :: Iam = 'clsm_ensdrv_get_command_line'
-    character(len=400) :: err_msg
-
-    !external getarg, iargc
-    
-    ! -----------------------------------------------------------------
-
-    ! make sure log file has already been opened
-
-    inquire( logunit, opened=outlog )
-
-    ! do not write log output for non-master processes as requested
-    
-    if ((log_master_only) .and. (.not. master_proc)) outlog = .false.
-    
-    N_args = iargc()
-    
-    i=0
-    
-    do while ( i < N_args )
-       
-       i = i+1
-       
-       call getarg(i,arg)
-       
-       if     ( trim(arg) == '-driver_inputs_path' ) then
-          i = i+1
-          if (present(driver_inputs_path))  call getarg(i,driver_inputs_path)
-          
-       elseif ( trim(arg) == '-driver_inputs_file' ) then
-          i = i+1
-          if (present(driver_inputs_file))  call getarg(i,driver_inputs_file)
-          
-       elseif ( trim(arg) == '-start_year' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(start_time))  read (arg,*) start_time%year
-          
-       elseif ( trim(arg) == '-start_month' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(start_time))  read (arg,*) start_time%month
-
-       elseif ( trim(arg) == '-start_day' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(start_time))  read (arg,*) start_time%day
-
-       elseif ( trim(arg) == '-start_hour' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(start_time))  read (arg,*) start_time%hour
-
-       elseif ( trim(arg) == '-start_min' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(start_time))  read (arg,*) start_time%min
-
-       elseif ( trim(arg) == '-start_sec' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(start_time))  read (arg,*) start_time%sec
-
-       elseif ( trim(arg) == '-end_year' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(end_time))  read (arg,*) end_time%year
-          
-       elseif ( trim(arg) == '-end_month' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(end_time))  read (arg,*) end_time%month
-
-       elseif ( trim(arg) == '-end_day' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(end_time))  read (arg,*) end_time%day
-
-       elseif ( trim(arg) == '-end_hour' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(end_time))  read (arg,*) end_time%hour
-
-       elseif ( trim(arg) == '-end_min' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(end_time))  read (arg,*) end_time%min
-
-       elseif ( trim(arg) == '-end_sec' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(end_time))  read (arg,*) end_time%sec
-
-       elseif ( trim(arg) == '-resolution' ) then
-          i = i+1
-          if (present(resolution))  call getarg(i,resolution)
-
-       elseif ( trim(arg) == '-exp_domain' ) then
-          i = i+1
-          if (present(exp_domain))  call getarg(i,exp_domain)
-
-       elseif ( trim(arg) == '-exp_id' ) then
-          i = i+1
-          if (present(exp_id))  call getarg(i,exp_id)
-
-       elseif ( trim(arg) == '-work_path' ) then
-          i = i+1
-          if (present(work_path))  call getarg(i,work_path)
-          
-       elseif ( trim(arg) == '-run_path' ) then
-          i = i+1
-          if (present(run_path))  call getarg(i,run_path)
-          
-       elseif ( trim(arg) == '-restart_path' ) then
-          i = i+1
-          if (present(restart_path))  call getarg(i,restart_path)
-          
-       elseif ( trim(arg) == '-restart_domain' ) then
-          i = i+1
-          if (present(restart_domain))  call getarg(i,restart_domain)
-
-       elseif ( trim(arg) == '-restart_id' ) then
-          i = i+1
-          if (present(restart_id))  call getarg(i,restart_id)
-          
-       elseif ( trim(arg) == '-tile_coord_path' ) then
-          i = i+1
-          if (present(tile_coord_path))     call getarg(i,tile_coord_path)
-          
-       elseif ( trim(arg) == '-tile_coord_file' ) then
-          i = i+1
-          if (present(tile_coord_file))     call getarg(i,tile_coord_file)
-          
-       elseif ( trim(arg) == '-catchment_def_path' ) then
-          i = i+1
-          if (present(catchment_def_path))  call getarg(i,catchment_def_path)
-          
-       elseif ( trim(arg) == '-catchment_def_file' ) then
-          i = i+1
-          if (present(catchment_def_file))  call getarg(i,catchment_def_file)
-
-       elseif ( trim(arg) == '-met_path' ) then
-          i = i+1
-          if (present(met_path))  call getarg(i,met_path)
-          
-       elseif ( trim(arg) == '-met_tag' ) then
-          i = i+1
-          if (present(met_tag))  call getarg(i,met_tag)
-          
-       elseif ( trim(arg) == '-force_dtstep' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(force_dtstep))  read (arg,*) force_dtstep
-          
-       elseif ( trim(arg) == '-restart' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(restart))  read (arg,*) restart
-
-       elseif ( trim(arg) == '-spin' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(spin))  read (arg,*) spin
-
-       elseif ( trim(arg) == '-ens_prop_inputs_path' ) then
-          i = i+1
-          if (present(ens_prop_inputs_path))  &
-               call getarg(i,ens_prop_inputs_path)
-          
-       elseif ( trim(arg) == '-ens_prop_inputs_file' ) then
-          i = i+1
-          if (present(ens_prop_inputs_file)) &
-               call getarg(i,ens_prop_inputs_file)
-          
-       elseif ( trim(arg) == '-N_ens' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(N_ens))  read (arg,*) N_ens
-
-       elseif ( trim(arg) == '-first_ens_id' ) then
-          i = i+1
-          call getarg(i,arg)
-          if (present(first_ens_id))  read (arg,*) first_ens_id
-          
-          
-          ! ignore arguments for assimilation, bias, adaptive estimation
-          
-       elseif ( trim(arg) == '-ens_upd_inputs_path' ) then
-          i = i+1
-          if (outlog) &
-               write (logunit,*) 'clsm_ensdrv_get_command_line(): IGNORING argument = ', &
-               trim(arg)
-       
-       elseif ( trim(arg) == '-ens_upd_inputs_file' ) then
-          i = i+1
-          if (outlog) &
-               write (logunit,*) 'clsm_ensdrv_get_command_line(): IGNORING argument = ', &
-               trim(arg)
-          
-       elseif ( trim(arg) == '-cat_bias_inputs_path' ) then
-          i = i+1
-          if (outlog) &
-               write (logunit,*) 'clsm_ensdrv_get_command_line(): IGNORING argument = ', &
-               trim(arg)
-          
-       elseif ( trim(arg) == '-cat_bias_inputs_file' ) then
-          i = i+1
-          if (outlog) &
-               write (logunit,*) 'clsm_ensdrv_get_command_line(): IGNORING argument = ', &
-               trim(arg)
-
-       elseif ( trim(arg) == '-adapt_inputs_path' ) then
-          i = i+1
-          if (outlog) &
-               write (logunit,*) 'clsm_ensdrv_get_command_line(): IGNORING argument = ', &
-               trim(arg)
-          
-       elseif ( trim(arg) == '-adapt_inputs_file' ) then
-          i = i+1
-          if (outlog) &
-               write (logunit,*) 'clsm_ensdrv_get_command_line(): IGNORING argument = ', &
-               trim(arg)
-          
-          ! stop for any other arguments
-          
-       else
-          
-          err_msg = 'unknown argument = ' // trim(arg)
-          call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
-
-       endif
-       
-    end do
-    
-  end subroutine clsm_ensdrv_get_command_line
-
   ! ***********************************************************************
 
 end module LDAS_ensdrv_init_routines

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_init_routines.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_init_routines.F90
@@ -207,7 +207,7 @@ contains
 
     else           
        
-       print*, "Creating domain..., reading white and black lists if there have ones..." 
+       print*, "Creating domain..., reading white and black lists if present..." 
        ! ------------------------------------------------------------
        !
        ! load blacklist: catchments listed in this file will be excluded


### PR DESCRIPTION
addresses #219 and #228 

NOT zero-diff (ApplyPrognPert bug fix)

enhancements:
- output of L-band Tb via HISTORY

nodata value decision:
- everything from HISTORY uses MAPL_UNDEF (1.e15)
- continue to use -9999 for LDASsa-heritage output Collections ("ObsFcstAna" and "smapL4SMaup") 

bug fixes:
- before the fix, ApplyPrognPert was executed too late and the current time step's prognostics perturbations were missed by the land analysis and by HISTORY
- no-data-handling in computation of ensemble average for surface temperature components

cleanup:
- avoid redundant entries in LDAS.rc
- setup for NUM_ENSEMBLE=1 with PERTURBATION=1
- added stop if output_smapL4SMaup==.true. and NUM_ENSEMBLE<=1
- removed obsolete LDASsa *_get_command_line() subroutines

documentation:
- improved help and log messages for setup and configuration
- updated README.md
- clarified comments in GEOS_LdasGridComp.F90

NOT addressed:
- improve tile_bin2nc4 utility to copy fillValue from GRADS ctl file into metadata of nc4 file
- ieee_value() in GEOS_EnsGridComp.F90 ??
- subdaily2daily concatenation for "inst1" files could be done if only files at the beginning of the day are missing (e.g., initial restart at 0z will not produce an inst1 file at 0z)

cc: @gmao-qliu 