### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /BUILD/
 /build*/
 /install*/
+/.mepo/
 parallel_build.o*


### PR DESCRIPTION
We should ignore the `.mepo` folder when `mepo` is used.