### PR TITLE
bugfix LDAS_move_new_force_to_old(): removed incorrect set-to-0 of non-GEOS flux-type forcing

### DIFF
--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -447,15 +447,6 @@ contains
      logical,intent(in) :: GEOS_forcing
      integer, intent(in) :: AEROSOL_DEPOSITION
 
-     old_force%Rainf_C = 0.0
-     old_force%Rainf   = 0.0
-     old_force%Snowf   = 0.0
-     old_force%LWdown  = 0.0
-     old_force%SWdown  = 0.0
-     old_force%SWnet   = 0.0
-     old_force%PARdrct = 0.0
-     old_force%PARdffs = 0.0
-     
      if (.not. GEOS_forcing) return
 
      old_force%Rainf_C = new_force%Rainf_C
@@ -477,6 +468,18 @@ contains
      new_force%PARdrct = nodata_generic
      new_force%PARdffs = nodata_generic
 
+     
+     ! [moved here from below, reichle, 28 Jan 2021]
+     ! treat Wind as flux when forcing with MERRA
+     if (MERRA_file_specs) then
+         old_force%Wind  = new_force%Wind
+         new_force%Wind  = nodata_generic
+     endif
+
+     ! not sure what exactly the following fields are and
+     ! whether it makes sense to include them here
+     ! - reichle, 28 Jan 2021
+     !
      if( AEROSOL_DEPOSITION /=0) then
 
         old_force%DUDP001 = new_force%DUDP001
@@ -603,12 +606,6 @@ contains
         new_force%SSSD005 = nodata_generic
 
      endif ! AEROSOL_DEPOSITION /=0
-
-     ! treat Wind as flux when forcing with MERRA
-     if (MERRA_file_specs) then
-         old_force%Wind  = new_force%Wind
-         new_force%Wind  = nodata_generic
-     endif
 
   end subroutine LDAS_move_new_force_to_old 
   ! ****************************************************************  


### PR DESCRIPTION
Addresses #359 

I am pretty sure that removing the lines "old_force%[xxx] = 0." at the beginning of the subroutine will fix the immediate issue with non-GEOS forcing data.

I have no idea why these lines were put there in the first place.  It is possible that removing them will somehow break something else.

@gmao-jkolassa : Please test the proposed solution in your use case with Fanwei's S2S forcing data.

@weiyuan-jiang : Please take a look at the source code to see if this makes sense to you.

@biljanaorescanin : Please run the usual set of GEOSldas tests.
