### PR TITLE
Update to ESMA_cmake v3.3.9

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.3.7
+  tag: v3.3.9
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR is just to keep GEOSldas "in sync" with GEOSgcm which recently moved to ESMA_cmake v3.3.9. This is essentially a no-op PR for GEOSldas as the [changes from v3.3.7 to v3.3.9](https://github.com/GEOS-ESM/ESMA_cmake/compare/v3.3.7...v3.3.9) are aimed more at the future of GEOS projects.

Namely, it adds a couple build options both of whose defaults right now are the status quo. Eventually, though, Baselibs will update and we'll need to flip one of the switches. 

Still, probably best @biljanaorescanin does a test. Though I cannot see this causing any change (@weiyuan-jiang can verify that too 😄 )