### PR TITLE
    use  assim alarm for centered_update option

### DIFF
--- a/src/Applications/LDAS_App/GEOSldas_HIST.rc
+++ b/src/Applications/LDAS_App/GEOSldas_HIST.rc
@@ -340,6 +340,9 @@ COLLECTIONS:
                                'TB_LAND_1410MHZ_40DEG_VPOL' , 'LANDASSIM'   , 'tb_v'                              ,
 			       ::
 
+# For catch_progn_incr, *.frequency and *.ref_time must be consistent with the LDAS.rc resource
+# parameters LANDASSIM_DT and LANDASSIM_T0.
+
   catch_progn_incr.descr:       'Tile-space,3-Hourly,Instantaneous,Single-Level,Assimilation,Ensemble-Average Land Prognostics Increments',
   catch_progn_incr.template:    '%y4%m2%d2_%h2%n2z.bin',
   catch_progn_incr.mode:        'instantaneous',
@@ -372,6 +375,9 @@ COLLECTIONS:
                                'SNDZN3_INCR'    , 'LANDASSIM'      ,
                          ::
 
+# For lndfcstana, *.frequency and *.ref_time must be consistent with the LDAS.rc resource
+# parameters LANDASSIM_DT and LANDASSIM_T0.
+
   inst3_1d_lndfcstana_Nt.descr:       'Tile-space,3-Hourly,Instantaneous,Single-Level,Assimilation,Ensemble-Average Land Forecast and Analysis Diagnostics',
   inst3_1d_lndfcstana_Nt.template:    '%y4%m2%d2_%h2%n2z.bin',
   inst3_1d_lndfcstana_Nt.mode:        'instantaneous',
@@ -388,6 +394,9 @@ COLLECTIONS:
                                      'TPSURF_ANA'  , 'LANDASSIM' , 'TSURF_ANA'       ,
                                      'TSOIL1_ANA'  , 'LANDASSIM' , 'TSOIL1_ANA'      ,
                         ::
+
+# For lndfcstana, *.frequency and *.ref_time must be consistent with the LDAS.rc resource
+# parameters LANDASSIM_DT and LANDASSIM_T0.
 
   inst3_2d_lndfcstana_Nx.descr:       '2d,3-Hourly,Instantaneous,Single-Level,Assimilation,Ensemble-Average Land Forecast and Analysis Diagnostics',
   inst3_2d_lndfcstana_Nx.template:    '%y4%m2%d2_%h2%n2z.nc4',

--- a/src/Applications/LDAS_App/GEOSldas_LDAS.rc
+++ b/src/Applications/LDAS_App/GEOSldas_LDAS.rc
@@ -71,6 +71,35 @@ MET_HINTERP: 1
 #
 LAND_ASSIM: NO
 
+# ---- Specify land assimilation times (when "LAND_ASSIM: YES")
+#
+#  LANDASSIM_DT : land analysis time step        (seconds) 
+#  LANDASSIM_T0 : land analysis "reference" time (hhmmss)
+# 
+#  LANDASSIM_T0 ("T0") and LANDASSIM_DT ("DT") define an infinite sequence of land analysis times:
+#
+#     ..., T0-3*DT, T0-2*DT, T0-DT, T0, T0+DT, T0+2*DT, T0+3*DT, ...
+#
+#  There is never a land analysis at the restart time.  Otherwise, the land analysis times are
+#  independent of the restart time.  There may be a land analysis at the final time.
+#
+#  LANDASSIM_DT must be <=86400s, be a multiple of HEARTBEAT_DT, and evenly divide a day.
+#  Consequently, only HHMMSS information is needed for LANDASSIM_T0.
+#
+#  Examples:
+#   T0=013000, DT=10800s --> land analysis whenever model time reaches 1:30z, 4:30z, ..., 22:30z.
+#   T0=163000, DT=10800s --> land analysis whenever model time reaches 1:30z, 4:30z, ..., 22:30z.
+#   T0=120000, DT=21600s --> land analysis whenever model time reaches 0z, 6z, 12z, and 18z.
+#
+#  LANDASSIM_DT and LANDASSIM_T0 work almost but not quite like "frequency" and "reftime" from MAPL
+#  HISTORY.  The difference is that MAPL HISTORY will not write output until "reftime" even when
+#  (reftime - restarttime)/frequency > 1.  E.g., if frequency=3h, reftime=9z, and restarttime=0z,
+#  then MAPL HISTORY will not write output until 9z, whereas with DT=3h, T0=9z, and restarttime=0z,
+#  the land analysis will be run at 3z, 6z, 9z, 12z, ...
+#
+# LANDASSIM_DT: 10800
+# LANDASSIM_T0: 000000   
+
 
 # ---- Perturbations: On/off 
 #

--- a/src/Applications/LDAS_App/GEOSldas_LDAS.rc
+++ b/src/Applications/LDAS_App/GEOSldas_LDAS.rc
@@ -177,6 +177,9 @@ LDAS_logit: YES
 #      User-defined path and filename of output (HISTORY) specification file.
 #      If empty, ldas_setup will generate a default HISTORY.rc file.
 #
+#      For the "catch_progn_incr" and "lndfcstana" output Collections, the "frequency" and "ref_time"
+#      settings must be consistent with "LANDASSIM_DT" and "LANDASSIM_T0" (see above).
+#
 # HISTRC_FILE: ''
 
 # ---- Concatenate sub-daily nc4 files into daily nc4 files and write monthly-mean output?

--- a/src/Applications/LDAS_App/LDASsa_DEFAULT_inputs_ensupd.nml
+++ b/src/Applications/LDAS_App/LDASsa_DEFAULT_inputs_ensupd.nml
@@ -5,6 +5,9 @@
 ! reichle,      13 Jun 2011 - updated for SMOS angles and downscaling ("FOV")
 ! reichle,       8 Jun 2017 - added "%flistpath" and "%flistname"; updated comments
 ! qliu+reichle, 29 Apr 2020 - added forecast error covariance inflation 
+! qzhang,wjiang,reichle,
+!                7 May 2021 - removed "dtstep_assim" and "centered_update"; replaced with MAPL
+!                             resource parameters "LANDASSIM_DT" and "LANDASSIM_T0" (in LDAS.rc)
 !
 ! --------------------------------------------------------------------
 
@@ -31,15 +34,6 @@
 ! update_type = 10: 3d soil moisture excl catdef/Tskin/ght(1);                             TB obs
 
 update_type = 0
-
-dtstep_assim = 10800   !  time step of assimilation (EnKF) updates
-
-! if "centered_update==.true." conduct first assimilation (EnKF) update 
-! after dtstep_assim/2 seconds (eg., at 1:30z when restarted at 0z with 
-! dtstep_assim of 3 hours), otherwise first update occurs after 
-! dtstep_assim seconds
-
-centered_update = .false.
 
 out_obslog      = .true.
 out_ObsFcstAna  = .false.

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1166,8 +1166,9 @@ contains
          )
     _VERIFY(status)
 
-    _ASSERT(mod(MAPL_nsecf(LandAssim_T0), model_dtstep)==0,                     &
-         "inconsistent inputs for HEARTBEAT_DT and LANDASSIM_T0")
+    s = MAPL_nsecf(LandAssim_T0)
+    
+    _ASSERT(mod(s, model_dtstep)==0,               "inconsistent inputs for HEARTBEAT_DT and LANDASSIM_T0")
     
     ! determine date and time of first land analysis
     !

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -379,20 +379,8 @@ contains
 
     if (logit) write (logunit,*) 'get_enkf_increments(): enter at ', &
          date_string, ', ', time_string
-
-    ! ----------------------------------------------------------------------
-    !
-    ! check whether it is time for assimilation
-
-    secs_in_day = date_time%hour*3600 + date_time%min*60 + date_time%sec
-
-    if (centered_update)  secs_in_day = secs_in_day + dtstep_assim/2
-
-    if (mod(secs_in_day, dtstep_assim)/=0) then
-
-       if (logit) write (logunit,*) 'NO EnKF increments for ', date_time2string(date_time)
-
-    else
+    if (logit) write (logunit,*) 'get_enkf_increments(): enter at anal time ', &
+         date_time2string(date_time)
 
        ! proceed with update
 
@@ -511,7 +499,7 @@ contains
           call date_and_time(date_string, time_string)  ! f90 intrinsic function
 
           if (logit) write (logunit,'(400A)') 'computing innovations starting at ' // &
-               date_string // ', ' // time_string
+                date_string // ', ' // time_string
 
           ! compute model forecast of observations
           ! (ensemble mean "obs_pred" is also stored in Observations_l%fcst)
@@ -1192,16 +1180,13 @@ contains
             N_catl, N_catf, N_obsl, tile_coord_f, tile_grid_g, N_catl_vec, low_ind,  &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn       )
 
-    end if
-
-    ! ---------------------------------------------------------------------------
-
-    ! end timer
 
     call date_and_time(date_string, time_string)
 
     if (logit) write (logunit,*) 'get_enkf_increments(): exit at ', &
-         date_string, ', ', time_string
+         date_string, ', ', time_string 
+    if (logit) write (logunit,*) 'get_enkf_increments(): exit at anal time ', &
+         date_time2string(date_time) 
 
   end subroutine get_enkf_increments
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -148,7 +148,7 @@ contains
        N_catl_vec, low_ind, l2f, f2l,                                    &
        N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
        update_type,                                                      &
-       dtstep_assim, centered_update,                                    &
+       dtstep_assim,                                                     &
        xcompact, ycompact, fcsterr_inflation_fac,                        &
        N_obs_param, obs_param, N_obsbias_max,                            &
        out_obslog, out_smapL4SMaup,                                      &
@@ -207,8 +207,6 @@ contains
     type(pert_param_type), dimension(:), pointer :: progn_pert_param ! input
 
     integer, intent(in) :: update_type, dtstep_assim
-
-    logical, intent(in) :: centered_update
 
     real,    intent(in) :: xcompact, ycompact, fcsterr_inflation_fac
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -255,8 +255,6 @@ contains
 
     ! local variables
 
-    integer :: secs_in_day
-
     integer :: N_obslH
 
     logical :: found_obs_f, assimflag
@@ -382,6 +380,8 @@ contains
     if (logit) write (logunit,*) 'get_enkf_increments(): enter at anal time ', &
          date_time2string(date_time)
 
+    if (.true.) then  ! replace obsolete check for analysis time with "if true" to keep indents
+       
        ! proceed with update
 
        ! -----------------------------------------------------------------
@@ -499,8 +499,8 @@ contains
           call date_and_time(date_string, time_string)  ! f90 intrinsic function
 
           if (logit) write (logunit,'(400A)') 'computing innovations starting at ' // &
-                date_string // ', ' // time_string
-
+               date_string // ', ' // time_string
+          
           ! compute model forecast of observations
           ! (ensemble mean "obs_pred" is also stored in Observations_l%fcst)
 
@@ -1180,13 +1180,12 @@ contains
             N_catl, N_catf, N_obsl, tile_coord_f, tile_grid_g, N_catl_vec, low_ind,  &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn       )
 
-
+    end if  ! end if (.true.)
+       
     call date_and_time(date_string, time_string)
 
     if (logit) write (logunit,*) 'get_enkf_increments(): exit at ', &
          date_string, ', ', time_string 
-    if (logit) write (logunit,*) 'get_enkf_increments(): exit at anal time ', &
-         date_time2string(date_time) 
 
   end subroutine get_enkf_increments
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -158,14 +158,11 @@ contains
        work_path,                               &
        exp_id,                                  &
        date_time,                               &
-       model_dtstep,                            &
        N_catf,             tile_coord_f,        &
        N_progn_pert,       progn_pert_param,    &
        N_force_pert,       force_pert_param,    &
        need_mwRTM_param,                        &
        update_type,                             &
-       dtstep_assim,                            &
-       centered_update,                         &
        xcompact, ycompact,                      &
        fcsterr_inflation_fac,                   &
        N_obs_param,                             &
@@ -199,8 +196,6 @@ contains
 
     type(date_time_type), intent(in)    :: date_time
     
-    integer,              intent(in)    :: model_dtstep
-
     integer,              intent(in)    :: N_catf, N_progn_pert, N_force_pert
     
     type(tile_coord_type), dimension(N_catf),       intent(in) :: tile_coord_f
@@ -210,9 +205,7 @@ contains
     
     logical,              intent(inout) :: need_mwRTM_param
 
-    integer,              intent(out)   :: update_type, dtstep_assim
-    
-    logical,              intent(out)   :: centered_update
+    integer,              intent(out)   :: update_type
     
     real,                 intent(out)   :: xcompact, ycompact
     real,                 intent(out)   :: fcsterr_inflation_fac
@@ -264,8 +257,6 @@ contains
     
     namelist /ens_upd_inputs/      &
          update_type,              &
-         dtstep_assim,             &
-         centered_update,          &
          out_obslog,               &
          out_ObsFcstAna,           &
          out_smapL4SMaup,          &
@@ -351,23 +342,6 @@ contains
        
     end do
 
-    ! consistency with model_dtstep
-    
-    ! dtstep_assim must be divisible by model_dtstep
-    
-    if ( (mod(dtstep_assim,model_dtstep)/=0) ) then
-       err_msg = 'inconsistent inputs for model_dtstep and dtstep_assim'
-       call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
-    end if
-    
-    ! if centered_update, dtstep_assim/model_dtstep must be even
-    
-    if ( (centered_update) .and. (mod(dtstep_assim/model_dtstep,2)/=0) ) then
-       err_msg = 'inconsistent inputs for ' // &
-            'model_dtstep, dtstep_assim, and centered_update'
-       call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
-    end if
-    
     ! -----------------------------------------------------------------
     !
     ! Extract only species of interest (i.e., %getinnov=.true.) from nml inputs:

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/GEOS_MetforceGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/GEOS_MetforceGridComp.F90
@@ -786,7 +786,7 @@ contains
     real, pointer :: LandTileLons(:)
     real, allocatable :: zth(:), slr(:), zth_tmp(:)
     type(met_force_type), allocatable :: mfDataNtp(:)
-    type(met_force_type), pointer :: DataTmp(:)=>null()
+    type(met_force_type), pointer, contiguous :: DataTmp(:)=>null()
     real, allocatable :: tmpreal(:)
     type(met_force_type) :: mf_nodata
 


### PR DESCRIPTION
1. Add centered_update option to the setting of the assim alarm  in GEOSlandassimGC Initialize. 
2. Remove  old code structure for centered_update option inhered from LDASsa.


 
- When centered_update = .true. in LDASsa_SPECIAL_inputs_ensupd.nml ,   analysis is carried out at the time centered in 3h forecast window ( for instance at 1:30Z  in 0 to 3Z model integration window) . 
- All analysis outputs are written at the corresponding time. For files controlled by MAPL,  in History.rc the ref.time need to be adjusted accordingly ( 01:30  instead of 00:00) .

