### PR TITLE
Update gitignore for mepo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 *~
 /@cmake/
-/@modules/
+/cmake/
+/cmake@/
 /@env/
+/env/
+/env@/
 /BUILD/
 /build*/
 /install*/

--- a/src/Components/GEOSldas_GridComp/.gitignore
+++ b/src/Components/GEOSldas_GridComp/.gitignore
@@ -1,2 +1,3 @@
 /@GEOSgcm_GridComp
-/@FVdycoreCubed_GridComp
+/GEOSgcm_GridComp
+/GEOSgcm_GridComp@

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -1,3 +1,6 @@
 /@GMAO_Shared
+/GMAO_Shared
+/GMAO_Shared@
 /@MAPL
-/@FMS
+/MAPL
+/MAPL@


### PR DESCRIPTION
Soon, `mepo` will have the ability to checkout subrepos as `repo`, `repo@`, or `@repo`. This commit updates the `.gitignore` files to support this flexibility.