### PR TITLE
Update env, cmake, and MAPL components to latest versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,6 @@ set (DOING_GEOS5 YES)
 
 # Should find a better place for this - used in Chem component
 set (ACG_FLAGS -v)
-set (F2PYEXT .so)
-set (F2PY_SUFFIX .so)
-set (FV_PRECISION R4)
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@cmake")
 include (esma)
@@ -43,3 +40,17 @@ include_directories(${MPI_Fortran_INCLUDE_PATH})
 # Recursively build source tree
 add_subdirectory (@env)
 add_subdirectory (src)
+
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# Piggyback that file into install
+install(
+   FILES ${PROJECT_BINARY_DIR}/.gitignore
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+   )
+
+

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.2.0
+  tag: v3.2.1
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.3.9
+  tag: v3.4.2
   develop: develop
 
 ecbuild:
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.4
+  tag: v2.6.7
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.7
+  tag: v2.6.8
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
This PR updates the GEOSldas to be "in sync" with the latest GCM. This includes:

* ESMA_env v3.2.1
* ESMA_cmake v3.4.2
* MAPL v2.6.7

I also cleaned up the main `CMakeLists.txt` as it had some anachronisms and was missing out on some neat functionality (automatically ignore build and install directories no matter the name).

I do not see any reason these should cause any differences. But of course, @biljanaorescanin should test to make sure.

I did a test build just to make sure that would work.