### PR TITLE
use v2.6.8 of MAPL

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.7
+  tag: v2.6.8
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
If we use extra oserver, we need v2.6.8