### PR TITLE
Updates for MAPL 2.7.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.8
+  tag: v2.7.0
   develop: develop
 
 GEOSgcm_GridComp:

--- a/src/Applications/LDAS_App/GEOSldas.F90
+++ b/src/Applications/LDAS_App/GEOSldas.F90
@@ -13,15 +13,17 @@ program LDAS_Main
 
    character(len=*), parameter :: Iam = "LDAS_Main"
    type (MAPL_Cap) :: cap
-   type (MAPL_FlapCapOptions) :: cap_options
+   type (MAPL_FlapCLI) :: cli
+   type (MAPL_CapOptions) :: cap_options
    integer :: status
 
 !EOP
 !----------------------------------------------------------------------
 !BOC
-   
-   cap_options = MAPL_FlapCapOptions(description = 'GEOS LDAS', &
-                                     authors     = 'GMAO')
+  
+   cli = MAPL_FlapCLI(description = 'GEOS LDAS', &
+                      authors     = 'GMAO')
+   cap_options = MAPL_CapOptions(cli)
    cap_options%egress_file = 'EGRESS.ldas'
 
    cap = MAPL_Cap('LDAS', ROOT_SetServices, cap_options = cap_options)


### PR DESCRIPTION
MAPL 2.7.0 changes the interface to how MAPL handles command line options. I believe this was done to better help MAPL work with NOAA UFS. (@weiyuan-jiang can explain more.)

This is my attempt to update GEOSldas for the new constructor. @weiyuan-jiang can let me know if I did it right. And I guess @biljanaorescanin can tell me too. Things won't build otherwise!