### PR TITLE
allocate some dummy variables to pass debugging mode

### DIFF
--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1662,9 +1662,13 @@ contains
     
     !   Weiyuan note: dummy adapt for now
     N_adapt_R = 0
-    !allocate(obs_pert_adapt_param(N_obs_param))
-    !allocate(Pert_adapt_R(N_adapt_R,NUM_ENSEMBLE))
-    !allocate(Obs_pert(N_obsl_max,NUM_ENSEMBLE))
+   ! allocate(obs_pert_adapt_param(N_obs_param))
+   ! allocate(Pert_adapt_R(N_adapt_R,NUM_ENSEMBLE))
+   ! allocate(Obs_pert(N_obsl_max,NUM_ENSEMBLE))
+   ! allocate zero size of array to pass in subroutine for debugging mode
+    allocate(obs_pert_adapt_param(0))
+    allocate(Pert_adapt_R(N_adapt_R,NUM_ENSEMBLE))
+    allocate(Obs_pert(0,NUM_ENSEMBLE))
     
     allocate(obs_bias(N_catl,N_obs_param,N_obsbias_max))
     if (N_obsbias_max>0) then
@@ -1801,7 +1805,7 @@ contains
          rc=status                                                              &
          )
     _VERIFY(status)   
-    
+   
     call get_enkf_increments(                                              &
          date_time_new,                                                    &
          NUM_ENSEMBLE, N_catl, N_catf, N_obsl_max,                         &

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -403,7 +403,7 @@ contains
                tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
                tile_grid_f, maxval(N_tile_in_cell_ij_f), tile_num_in_cell_ij_f )
        else
-          allocate(N_tile_in_cell_ij_f(1,1)) !for debugging
+          allocate(N_tile_in_cell_ij_f(0,0)) !for debugging
        end if
 
        ! *********************************************************************
@@ -705,7 +705,7 @@ contains
           if (root_proc) then
             allocate(indTiles_f(nTiles_f), source=-99)
           else
-            allocate(indTiles_f(1)) ! for debugging mode
+            allocate(indTiles_f(0)) ! for debugging mode
           endif
   
           if (root_proc) then
@@ -848,7 +848,7 @@ contains
           if (root_proc) then
              allocate(cat_param_f(N_catf))
           else
-             allocate(cat_param_f(1)) !for debugging mode
+             allocate(cat_param_f(0)) !for debugging mode
           endif
           call MPI_Gatherv(                                             &
                cat_param,   N_catl,                MPI_cat_param_type,  &
@@ -878,7 +878,7 @@ contains
           if (root_proc) then
              allocate(cat_progn_f(N_catf))
           else
-             allocate(cat_progn_f(1)) ! for debugging mode
+             allocate(cat_progn_f(0)) ! for debugging mode
           endif
 
           allocate(cat_progn_ana(nTiles_ana,N_ens))
@@ -930,7 +930,7 @@ contains
           if (root_proc) then
              allocate(Obs_pred_f_assim(N_obsf_assim))
           else
-             allocate(Obs_pred_f_assim(1)) ! for debugging mode
+             allocate(Obs_pred_f_assim(0)) ! for debugging mode
           endif
           allocate(Obs_pred_ana(nObs_ana,N_ens), source=0.)
           if (root_proc) then
@@ -1094,7 +1094,7 @@ contains
              allocate(cat_progn_incr_f(N_catf))
              allocate(recvBuf(maxval(nTilesAna_vec))) ! temp storage of incoming data
           else
-             allocate(cat_progn_incr_f(1)) ! for debugging
+             allocate(cat_progn_incr_f(0)) ! for debugging
           end if
           do iEns=1,N_ens
              ! cat_progn_incr_ana -> cat_progn_incr_f

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -1477,7 +1477,7 @@ contains
 
        end do
     else
-      allocate(Observations_f(1))
+      allocate(Observations_f(0))
     end if
 
 #ifdef LDAS_MPI
@@ -2173,7 +2173,7 @@ contains
 
           end do
        else
-         allocate(Observations_f(1))
+         allocate(Observations_f(0))
        end if
 
 #ifdef LDAS_MPI

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -402,6 +402,8 @@ contains
           call get_tile_num_in_cell_ij( N_catf,                                  &
                tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
                tile_grid_f, maxval(N_tile_in_cell_ij_f), tile_num_in_cell_ij_f )
+       else
+          allocate(N_tile_in_cell_ij_f(1,1)) !for debugging
        end if
 
        ! *********************************************************************
@@ -700,7 +702,12 @@ contains
           end if
              
           ! Step 2b: indTiles_l -> indTiles_f (on root)
-          if (root_proc) allocate(indTiles_f(nTiles_f), source=-99)
+          if (root_proc) then
+            allocate(indTiles_f(nTiles_f), source=-99)
+          else
+            allocate(indTiles_f(1)) ! for debugging mode
+          endif
+  
           if (root_proc) then
              tmp_low_ind(1) = 1
              do iproc=1,numprocs-1
@@ -838,7 +845,11 @@ contains
           tile_coord_ana = tile_coord_f(indTiles_ana)
 
           ! Step 4c: cat_param(N_catl) -> cat_param_f (on root) -> cat_param_ana
-          if (root_proc) allocate(cat_param_f(N_catf))
+          if (root_proc) then
+             allocate(cat_param_f(N_catf))
+          else
+             allocate(cat_param_f(1)) !for debugging mode
+          endif
           call MPI_Gatherv(                                             &
                cat_param,   N_catl,                MPI_cat_param_type,  &
                cat_param_f, N_catl_vec, low_ind-1, MPI_cat_param_type,  &
@@ -864,7 +875,12 @@ contains
 
           ! Step 4d: cat_progn -> cat_progn_f (on root) -> cat_progn_ana
           ! one ensemble at a time
-          if (root_proc) allocate(cat_progn_f(N_catf))
+          if (root_proc) then
+             allocate(cat_progn_f(N_catf))
+          else
+             allocate(cat_progn_f(1)) ! for debugging mode
+          endif
+
           allocate(cat_progn_ana(nTiles_ana,N_ens))
           allocate(tmp_cat_progn_ana(nTiles_ana)) ! CSD-BUGFIX
 
@@ -911,7 +927,11 @@ contains
 
           ! Step 4e: Obs_pred_l (obs%assim=.true.) -> Obs_pred_f_assim (on root) -> Obs_pred_ana
           ! one ensemble at a time
-          if (root_proc) allocate(Obs_pred_f_assim(N_obsf_assim))
+          if (root_proc) then
+             allocate(Obs_pred_f_assim(N_obsf_assim))
+          else
+             allocate(Obs_pred_f_assim(1)) ! for debugging mode
+          endif
           allocate(Obs_pred_ana(nObs_ana,N_ens), source=0.)
           if (root_proc) then
              tmp_low_ind(1) = 1
@@ -1073,6 +1093,8 @@ contains
           if (root_proc) then
              allocate(cat_progn_incr_f(N_catf))
              allocate(recvBuf(maxval(nTilesAna_vec))) ! temp storage of incoming data
+          else
+             allocate(cat_progn_incr_f(1)) ! for debugging
           end if
           do iEns=1,N_ens
              ! cat_progn_incr_ana -> cat_progn_incr_f
@@ -1454,7 +1476,8 @@ contains
           tmp_low_ind(n+1) = tmp_low_ind(n) + N_obsl_vec(n)
 
        end do
-
+    else
+      allocate(Observations_f(1))
     end if
 
 #ifdef LDAS_MPI
@@ -1591,9 +1614,9 @@ contains
 
        close(10,status='keep')
 
-       deallocate(Observations_f)
 
     end if
+    if (allocated(Observations_f)) deallocate(Observations_f)
 
   end subroutine output_ObsFcstAna
 
@@ -2149,7 +2172,8 @@ contains
              tmp_low_ind(n+1) = tmp_low_ind(n) + N_obsl_vec(n)
 
           end do
-
+       else
+         allocate(Observations_f(1))
        end if
 
 #ifdef LDAS_MPI
@@ -2776,7 +2800,6 @@ contains
 
           ! clean up
 
-          deallocate(Observations_f)
 
           deallocate(col_beg_9km)
           deallocate(col_end_9km)
@@ -2798,6 +2821,7 @@ contains
           deallocate(data_v_9km_tile)
 
        end if  ! root_proc
+       if(allocated(Observations_f)) deallocate(Observations_f)
 
     end if     ! (option=='orig_obs' .or. option=='obs_fcst')
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -1441,7 +1441,7 @@ contains
     ! determine N_catlH and tile_coord_lH  
 
     N_fields = 0  ! set to zero temporarily, not yet needed
-    
+    allocate(tile_data_l(0,0,0))  ! for debugging to pass  
     call get_tiles_in_halo( N_catl, N_fields, N_ens, tile_data_l, tile_coord_l,  &
          N_catf, tile_coord_f, N_catl_vec, low_ind, xhalo, yhalo,                &
          N_catlH, tile_coord_lH=tile_coord_lH )
@@ -1463,6 +1463,7 @@ contains
     
     ! allocate and assemble tile_data_l
     
+    if (allocated(tile_data_l))  deallocate(tile_data_l)
     allocate(tile_data_l(N_catl,N_fields,N_ens))
     
     call get_obs_pred_comm_helper( N_catl, N_ens, N_TbuniqFreqAngRTMid,          &

--- a/src/Components/GEOSldas_GridComp/Shared/my_matrix_functions.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/my_matrix_functions.F90
@@ -15,6 +15,7 @@ module my_matrix_functions
   !public :: adjust_mean
   !public :: matrix_std
   public :: unique_rows_3col
+  public :: unique_rows_2col
   
 contains
 
@@ -1019,7 +1020,8 @@ end program test_five_number_summary
 #if 0
 
 program test_unique_rows
-  
+
+  use my_matrix_functions, ONLY: unique_rows_2col  
   implicit none
   
   integer, parameter :: N_rows = 55    ! 6
@@ -1109,7 +1111,7 @@ program test_unique_rows
      write (*,*) A(i,:)
   end do
   
-  call unique_rows_2col( N_rows, N_cols, A, N_unique_rows, ind_A2U)
+  call unique_rows_2col( N_rows, A, N_unique_rows, ind_A2U)
   
   write (*,*) N_unique_rows
   do i=1,N_unique_rows

--- a/src/Components/GEOSldas_GridComp/Shared/my_matrix_functions.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/my_matrix_functions.F90
@@ -746,8 +746,8 @@ contains
 
     ind_A2U       = ind_A2U_step2
 
-    A(:,1:2)      = A_step1(nint(A_step2(1:N_step2,1)),:)
-    A(:,  3)      = A_step2(             1:N_step2    ,2)
+    A(1:N_step2,1:2)      = A_step1(nint(A_step2(1:N_step2,1)),:)
+    A(1:N_step2,  3)      = A_step2(             1:N_step2    ,2)
     
   end subroutine unique_rows_3col
 

--- a/src/Components/GEOSldas_GridComp/Shared/my_matrix_functions.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/my_matrix_functions.F90
@@ -15,7 +15,7 @@ module my_matrix_functions
   !public :: adjust_mean
   !public :: matrix_std
   public :: unique_rows_3col
-  public :: unique_rows_2col
+  !public :: unique_rows_2col
   
 contains
 


### PR DESCRIPTION
In debugging mode,  the subroutines need allocated arguments. 