### PR TITLE
Update to Baselibs 6.2.4. Enable GFE Namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gcc-build-env:
     docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.1.1-openmpi_4.0.5-gcc_10.3.0
+      - image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.2.1
+  tag: v3.3.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.4.2
+  tag: v3.5.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR brings GEOSldas up-to-date with GEOSgcm v10.19.2. The change is two-fold:

1. Updates to Baselibs 6.2.4
2. Enables GFE Namespace in CMake

Note that the nightly testing framework will need to change with it so that the GNU tests are using the 6.2.4 Baselibs g5_modules (if not, build failure).

Note 2: I'm marking as 0-diff as it should be, but should be tested!