### PR TITLE
bug fix in no-data check in mwRTM_routines.F90

### DIFF
--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_routines.F90
@@ -369,9 +369,9 @@ contains
        ! to check one field of mwp because mwRTM_param_nodata_check()
        ! is called in mwRTM_get_param()]
        
-       if ( (SWE(n)<SWE_threshold)                            .and.         &
-            (soiltemp(n)>tsoil_threshold)                     .and.         &
-            (mwp(n)%sand-nodata_generic>nodata_tol_generic) )        then
+       if ( (SWE(n)<SWE_threshold)                                 .and.         &
+            (soiltemp(n)>tsoil_threshold)                          .and.         &
+            (abs(mwp(n)%sand-nodata_generic)>nodata_tol_generic) )        then
        
           ! soil dielectric constant
           


### PR DESCRIPTION
This bug was present from the very first implementation of the microwave radiative transfer model (mwRTM) in the LDASsa CVS tag `reichle-LDASsa_m2-10`.
I'm 99.99% confident that the fix is 0-diff, but I haven't tested it.
@biljanaorescanin, can you please test?  If it's indeed 0-diff, go ahead and merge. 

cc: @gmao-qliu 