### PR TITLE
add unsetenv ld_library_path to  lenkf.j.template

### DIFF
--- a/src/Applications/LDAS_App/lenkf.j.template
+++ b/src/Applications/LDAS_App/lenkf.j.template
@@ -28,6 +28,7 @@ setenv EXPDOMAIN  MY_EXPDOMAIN
 setenv EXPDIR     MY_EXPDIR
 setenv ESMADIR    $EXPDIR/build/
 setenv GEOSBIN    $ESMADIR/bin/
+unsetenv LD_LIBRARY_PATH
 source $GEOSBIN/g5_modules
 
 setenv I_MPI_DAPL_UD enable

--- a/src/Applications/LDAS_App/lenkf.j.template
+++ b/src/Applications/LDAS_App/lenkf.j.template
@@ -28,6 +28,7 @@ setenv EXPDOMAIN  MY_EXPDOMAIN
 setenv EXPDIR     MY_EXPDIR
 setenv ESMADIR    $EXPDIR/build/
 setenv GEOSBIN    $ESMADIR/bin/
+# need to unsetenv LD_LIBRARY_PATH for execution of LDAS within the coupled land-atm DAS
 unsetenv LD_LIBRARY_PATH
 source $GEOSBIN/g5_modules
 


### PR DESCRIPTION
unsetenv ld_library_path before source g5_modules to avoid having $fvroot/lib inherited from adas  in LADAS  