### PR TITLE
Update ESMA_cmake to v3.5.5, update CI and CMakeLists.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 executors:
-  gcc-build-env:
+  gfortran-large:
     docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
+      - image: gmao/ubuntu20-geos-env-mkl:v6.2.7-openmpi_4.0.6-gcc_11.2.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN
@@ -14,24 +14,39 @@ executors:
     resource_class: large
     #MEDIUM# resource_class: medium
 
+  ifort-large:
+    docker:
+      - image: gmao/ubuntu20-geos-env:v6.2.7-intelmpi_2021.2.0-intel_2021.2.0
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_AUTH_TOKEN
+    resource_class: large
+    #MEDIUM# resource_class: medium
+
 workflows:
-  version: 2.1
   build-test:
     jobs:
       - build-GEOSldas:
+          name: build-GEOSldas-on-<< matrix.compiler >>
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
           context:
             - docker-hub-creds
 
 jobs:
   build-GEOSldas:
-    executor: gcc-build-env
+    parameters:
+      compiler:
+        type: string
+    executor: << parameters.compiler >>-large
     working_directory: /root/project
     steps:
       - checkout:
           path: GEOSldas
       - run:
           name: "Versions etc"
-          command: mpirun --version && gfortran --version && echo $BASEDIR && pwd && ls
+          command: mpirun --version && << parameters.compiler>> --version && echo $BASEDIR && pwd && ls
       - run:
           name: "Mepo clone external repos"
           command: |
@@ -51,13 +66,16 @@ jobs:
       - run:
           name: "CMake"
           command: |
+            mkdir -p /logfiles
             cd ${CIRCLE_WORKING_DIRECTORY}/GEOSldas
-            mkdir build
-            cd build
-            cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_BUILD_TYPE=Debug -DUSE_F2PY=OFF
+            mkdir -p  ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSldas
+            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSldas
+            cmake ${CIRCLE_WORKING_DIRECTORY}/GEOSldas -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=<< parameters.compiler >> -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${CIRCLE_WORKING_DIRECTORY}/workspace/install-GEOSldas -DUSE_F2PY=OFF |& tee /logfiles/cmake.log
       - run:
-          name: "Build"
+          name: "Build and install"
           command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSldas/build
-            make -j"$(nproc)" install
-            #MEDIUM# make -j4 install
+            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSldas
+            make -j"$(nproc)" install |& tee /logfiles/make.log
+            #MEDIUM# make -j4 install |& tee /logfiles/make.log
+      - store_artifacts:
+          path: /logfiles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui
   set_property (CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    "Debug" "Release" "Aggressive")
 endif ()
 
 set (DOING_GEOS5 YES)
@@ -53,4 +53,5 @@ install(
    DESTINATION ${CMAKE_INSTALL_PREFIX}
    )
 
-
+# Adds abiilty to tar source
+include (esma_cpack)

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.2
+  tag: v3.5.5
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
Closes #443 

This PR updates GEOSldas to use ESMA_cmake v3.5.5 which has a fix for a build issue encountered by @alexgruber. I haven't yet seen this issue on any NASA system, but testing with GEOSgcm shows this as a zero-diff change that makes no difference with Intel or GNU.

Obviously, @biljanaorescanin will want to do an official LDAS test but I think it's good. 🤞🏼 

**ETA**: I decided to add to this updates for the CI and `CMakeLists.txt` for GEOSldas. 

The CI update adds support for both Intel and GNU, rather than just GNU.

As for `CMakeLists.txt`, it fixes it up so that it only "supports" the three Build Types that the GEOS build system actually does support. It also adds a `make package_source` or `make dist` command that will make a tarball of the source code from a build directory. (This is for use with, say, Zenodo when a user needs to upload a tarball.)

