### PR TITLE
update MAPL for shave bit function

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.8.2
+  tag: v2.8.6
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
New MAPL is able to apply shaving bit to binary history output. This PR matches the MAPL and helps to compress GEOSldas binary history output if nbits is specified in HISTORY.rc 