### PR TITLE
Update GEOSldas version info in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSldas
-  VERSION 17.8
+  VERSION 17.9
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")


### PR DESCRIPTION
@mathomp4, is this what you had in mind for CMakeLists.txt?
Or can we use "v17" instead of "v17.9" to cut down in the number of manual interventions?  Maybe that would defeat the purpose, though...