### PR TITLE
Updated CHANGELOG.md: removed obsolete change note

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -51,7 +51,6 @@ Overview of Git Releases:
 
 - Bug fixes and other minor changes:
   - Minor fixes for GNU compiler.
-  - Updated LICENSE.md. 
   - Fixed PAR handling in get_GEOSs2s().
 
 - Note: v17.9.6 fixes v17.9.5, which did not compile with GNU and was deleted soon after release.


### PR DESCRIPTION
I just realized that an entry in the description of v17.9.6 in CHANGELOG.md is obsolete.  This PR removes the obsolete entry.  There is no need to change the main branch or release v17.9.6.  The correction will become part of future releases.