### PR TITLE
Updates for Cascade Lakes at NCCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /install*/
 /.mepo/
 parallel_build.o*
+log.*
+CMakeUserPresets.json

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.3.0
+  tag: v3.4.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.5
+  tag: v3.6.0
   develop: develop
 
 ecbuild:

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -1510,7 +1510,7 @@ def _printRmInputKeys(rqdRmInpKeys, optRmInpKeys):
     print '# - walltime         = walltime requested; format is HH:MM:SS (hours/minutes/seconds)'
     print '# - ntasks_model     = number of processors requested for the model (typically 112; output server is not included)'
     print '# - ntasks-per-node  = number of tasks per node (typically 48 for cascade lake, 40 for skylake, and 28 for haswell nodes)'
-    print '#                      [If >48, cascade lake nodes will be allocated, if >40, cascade or skylake, else cascade, skylake or haswell.]'
+    print '#                      [If >40, cascade lake nodes will be allocated, if >28, cascade or skylake, else cascade, skylake or haswell.]'
     print '#'
     for key in rqdRmInpKeys:
         print key + ':'

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -1241,8 +1241,8 @@ class LDASsetup:
                     elif 'MY_NODES' in line :
                         line_ = line.replace('MY_NODES',str(self.optRmInp['nodes']))
                         fout.write(line_.replace('MY_NTASKS_PER_NODE',str(self.rqdRmInp['ntasks-per-node'])))
-                        if int(self.rqdRmInp['ntasks-per-node']) > 28:
-                           fout.write("#SBATCH --constraint=sky\n")
+                        if int(self.rqdRmInp['ntasks-per-node']) > 40:
+                           fout.write("#SBATCH --constraint=cas\n")
                     elif 'MY_OSERVER_NODES' in line :
                         fout.write(line.replace('MY_OSERVER_NODES',str(self.optRmInp['oserver_nodes'])))
                     elif 'MY_WRITERS_NPES' in line :
@@ -1509,8 +1509,8 @@ def _printRmInputKeys(rqdRmInpKeys, optRmInpKeys):
     print '#                      [At NCCS: Use command "getsponsor" to see available account number(s).]'  
     print '# - walltime         = walltime requested; format is HH:MM:SS (hours/minutes/seconds)'
     print '# - ntasks_model     = number of processors requested for the model (typically 112; output server is not included)'
-    print '# - ntasks-per-node  = number of tasks per node (typically 40 for skylake and 28 for haswell nodes)'
-    print '#                      [If >28, skylake nodes will be allocated, else skylake or haswell.]'
+    print '# - ntasks-per-node  = number of tasks per node (typically 48 for cascade lake, 40 for skylake, and 28 for haswell nodes)'
+    print '#                      [If >48, cascade lake nodes will be allocated, if >40, cascade or skylake, else cascade, skylake or haswell.]'
     print '#'
     for key in rqdRmInpKeys:
         print key + ':'


### PR DESCRIPTION
This is an update to GEOSldas that is needed to use Cascade Lake nodes at NCCS. (There is a similar PR in for GEOSgcm, see https://github.com/GEOS-ESM/GEOSgcm/pull/335)

First, ESMA_env is moved to v3.4.0 which moves the Intel compiler to Intel 2021.2 (needed on Cascade Lake). Next, ESMA_cmake v3.6.0 updates the Intel `Release` flags to be vectorized everywhere. Testing with GEOSgcm has shown that these changes are indeed zero-diff (and faster than old `Release` flags). However, I have not yet tested this with the GEOSldas. @weiyuan-jiang or @biljanaorescanin might be best equipped to do this.

I've also taken a stab at updating `ldas_setup` for the Cascade Lakes. I probably got it...close? I suppose @gmao-rreichle and @weiyuan-jiang can take a look. 

I'll keep this a draft until all necessary people can chime in. I suppose the two main questions are:

1. Is the update to Intel 2021.2 and the change to `Release` flags zero-diff?
2. Is `ldas_setup` correctly set up to work on Cascade Lake?
3. Is LDAS any faster in `Release` mode with the new flags?

As such, I've labeled this as 0-diff and not 0-diff and put a blocker on it.