### PR TITLE
 when LADAS_COUP =1, (1) copy $FVWORK/forcing files to scratch/    (2) make forc path to scratch/ 

### DIFF
--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -1456,7 +1456,7 @@ def _printExeInputKeys(rqdExeInpKeys):
     print '#  (3) MET_TAG  must be set to [ADAS_EXPID]__Nx+-          #'
     print '#      MET_PATH must be set as follows for                 #'
     print '#        LADAS_COUPLING = 1:                               #'        
-    print '#          [ADAS_EXPDIR]/lana/forc                         #'        
+    print '#          ../../scratch                                   #'        
     print '#        LADAS_COUPLING = 2:                               #'        
     print '#          [ADAS_EXPDIR]/atmens/ensdiag/forc               #'
     print '#      After ldas exp setup, verify the following link:    #'        

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -1456,7 +1456,7 @@ def _printExeInputKeys(rqdExeInpKeys):
     print '#  (3) MET_TAG  must be set to [ADAS_EXPID]__Nx+-          #'
     print '#      MET_PATH must be set as follows for                 #'
     print '#        LADAS_COUPLING = 1:                               #'        
-    print '#          ../../scratch                                   #'        
+    print '#          [full_path]/[LDAS_EXPID]/scratch/               #'        
     print '#        LADAS_COUPLING = 2:                               #'        
     print '#          [ADAS_EXPDIR]/atmens/ensdiag/forc               #'
     print '#      After ldas exp setup, verify the following link:    #'        

--- a/src/Applications/LDAS_App/lenkf.j.template
+++ b/src/Applications/LDAS_App/lenkf.j.template
@@ -113,8 +113,7 @@ endif
 ########################################################################
 
 if ( $LADAS_COUPLING == 1 ) then
-   echo $FVWORK
-   ls $FVWORK/*lfo_Nx+-*nc4
+   echo "copying lfo_Nx+- met forcing from $FVWORK to $SCRDIR"
    /bin/cp -f $FVWORK/*lfo_Nx+-*nc4  $SCRDIR/.
 endif
 

--- a/src/Applications/LDAS_App/lenkf.j.template
+++ b/src/Applications/LDAS_App/lenkf.j.template
@@ -108,6 +108,16 @@ if( ${LSMCHOICE} > 1 ) then # CatchCN Only
     ln -s /discover/nobackup/projects/gmao/ssd/land/l_data/LandBCs_files_for_mkCatchParam/V001/FPAR_CDF_Params-M09.nc4
 endif
 
+########################################################################
+#    if $LADAS_COUPLING == 1 use $FVWORK and copy forcing to Scratch
+########################################################################
+
+if ( $LADAS_COUPLING == 1 ) then
+   echo $FVWORK
+   ls $FVWORK/*lfo_Nx+-*nc4
+   /bin/cp -f $FVWORK/*lfo_Nx+-*nc4  $SCRDIR/.
+endif
+
 #######################################################################
 #              Create HISTORY Collection Directories
 #######################################################################


### PR DESCRIPTION
when LADAS_COUPLING = 1 , forcing path was set with symbolic link to adas/lana/forc -> $FVWORK. There were occasional failures for the links during some coupled experiment run.
lenkf can use the env. variable $FVWORK during a coupled run to copy $FVWORK/forcing files to scratch/. the forc path can be set to scratch/ correspondingly. 
The modifications have been tested in a coupled experiment run. 