### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,13 @@
 # LDAS Gatekeepers own all files
 * @GEOS-ESM/ldas-gatekeepers
 
-# The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
-CMakeLists.txt @GEOS-ESM/cmake-team
+# The LDAS gatekeepers and CMake should know/approve these
+/.github/    @GEOS-ESM/cmake-team @GEOS-ESM/ldas-gatekeepers
+/.circleci/  @GEOS-ESM/cmake-team @GEOS-ESM/ldas-gatekeepers
+/.codebuild/ @GEOS-ESM/cmake-team @GEOS-ESM/ldas-gatekeepers
 
+# The GEOS CMake Team should be notified about changes to the CMakeLists.txt files in this repository
+CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/ldas-gatekeepers
+
+# The GEOS CMake Team should be notified about and approve config changes
+/config/ @GEOS-ESM/cmake-team @GEOS-ESM/ldas-gatekeepers


### PR DESCRIPTION
Realized that the @GEOS-ESM/ldas-gatekeepers were not co-owners of their own CMake files. Of course they should have to approve any CMake changes. Bad GitHub CODEOWNERS logic by Matt.