### PR TITLE
Compress CircleCI Artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,5 +77,9 @@ jobs:
             cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSldas
             make -j"$(nproc)" install |& tee /logfiles/make.log
             #MEDIUM# make -j4 install |& tee /logfiles/make.log
+      - run:
+          name: "Compress artifacts"
+          command: |
+            gzip -9 /logfiles/*
       - store_artifacts:
           path: /logfiles


### PR DESCRIPTION
This PR compresses the CircleCI artifacts since CircleCI will soon charge for storage over a limit:

https://circleci.com/docs/2.0/persist-data/#storage

This is trivially zero-diff to the model as it only affects CI