### PR TITLE
remove catchincr grid comp when it is not land_assim

### DIFF
--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -982,29 +982,31 @@ contains
       RC=STATUS)
 
 !
-   call MAPL_GetResource ( MAPL, NUM_ENSEMBLE, Label="NUM_LDAS_ENSEMBLE:", DEFAULT=1, RC=STATUS)
-   _VERIFY(STATUS)
-   call MAPL_GetResource ( MAPL, FIRST_ENS_ID, Label="FIRST_ENS_ID:", DEFAULT=0, RC=STATUS)
-   _VERIFY(STATUS)
-   call MAPL_GetResource ( MAPL, ens_id_width, Label="ENS_ID_WIDTH:",      DEFAULT=0,       RC=STATUS)
-   VERIFY_(STATUS)
+   if ( land_assim ) then
+      call MAPL_GetResource ( MAPL, NUM_ENSEMBLE, Label="NUM_LDAS_ENSEMBLE:", DEFAULT=1, RC=STATUS)
+      _VERIFY(STATUS)
+      call MAPL_GetResource ( MAPL, FIRST_ENS_ID, Label="FIRST_ENS_ID:", DEFAULT=0, RC=STATUS)
+      _VERIFY(STATUS)
+      call MAPL_GetResource ( MAPL, ens_id_width, Label="ENS_ID_WIDTH:",      DEFAULT=0,       RC=STATUS)
+      VERIFY_(STATUS)
 
-   write (fmt_str, "(A2,I1,A1,I1,A1)") "(I", ens_id_width,".",ens_id_width,")"
-   allocate(ens_id(NUM_ENSEMBLE), export_id(NUM_ENSEMBLE))
-   do i=1,NUM_ENSEMBLE
-      ens_id(i) = i-1 + FIRST_ENS_ID ! id start form FIRST_ENS_ID
-      if (NUM_ENSEMBLE == 1 ) then
-         id_string=''
-      else
-         write(id_string, fmt_str) ens_id(i)
-      endif
+      write (fmt_str, "(A2,I1,A1,I1,A1)") "(I", ens_id_width,".",ens_id_width,")"
+      allocate(ens_id(NUM_ENSEMBLE), export_id(NUM_ENSEMBLE))
+      do i=1,NUM_ENSEMBLE
+         ens_id(i) = i-1 + FIRST_ENS_ID ! id start form FIRST_ENS_ID
+         if (NUM_ENSEMBLE == 1 ) then
+            id_string=''
+         else
+            write(id_string, fmt_str) ens_id(i)
+         endif
 
-      id_string=trim(id_string)
+         id_string=trim(id_string)
 
-      childname='CATCHINCR'//trim(id_string)
-      export_id(i) = MAPL_AddChild(gc, name=childname, ss=ExportCatchIncrSetServices, rc=status)
-      VERIFY_(status)
-   enddo
+         childname='CATCHINCR'//trim(id_string)
+         export_id(i) = MAPL_AddChild(gc, name=childname, ss=ExportCatchIncrSetServices, rc=status)
+         VERIFY_(status)
+      enddo
+   endif
 
    call MAPL_TimerAdd(GC, name="Initialize"    ,RC=STATUS)
    _VERIFY(STATUS)


### PR DESCRIPTION
UPDATED by @gmao-rreichle:
This PR fixes a problem reported by @gmao-qliu on 3 Jan 2022:
When GEOSldas v17.10.0 is used to write out L-band Tb data in a single-member simulation without perturbations and without data assimilation (ie, land_assim=no), the run crashes during MAPL_GenericInitialize() in the LandAssim GridComp (when the mwRTM parameters are read from the restart file).  There is no crash when v17.10.0 is used in an ensemble data assimilation configuration. 

The single-member, no assimilation configuration with Tb output is needed for the SMAP Nature Run (e.g., NR5000) that is delivered to the SMAP Project at JPL.  The last tag for which this is known to work is v17.9.0-beta.8 (currently used for NR5000).  


---
@saraqzhang Would you please verify this PR for me? The question here is if there exists such scenario that it is not land_assim but needs catchincr grid comp? 