### PR TITLE
Update to MAPL v2.15.0, remove EXPDSC: and EXPSRC: from GEOSldas_HIST.rc

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.14.1
+  tag: v2.15.0
   develop: develop
 
 GEOSgcm_GridComp:

--- a/src/Applications/LDAS_App/GEOSldas_HIST.rc
+++ b/src/Applications/LDAS_App/GEOSldas_HIST.rc
@@ -13,11 +13,6 @@
 #
 EXPID:  GEOSldas_expid
 
-# Experiment description and source code info are expected by MAPL but  
-#  not used (as of 13 Oct 2021).
-EXPDSC: GEOSldas_output
-EXPSRC: GEOSldas
-
 COLLECTIONS:
 #EASE            'tavg24_1d_lfs_Nt'
 #CUBE            'tavg24_2d_lfs_Nx'	


### PR DESCRIPTION
GEOSldas_HIST.rc included EXPDSC: and EXPSRC: which were expected by MAPL but not used.  See [MAPL issue #1080](https://github.com/GEOS-ESM/MAPL/issues/1080).
[MAPL pull request #1256](https://github.com/GEOS-ESM/MAPL/pull/1256) made these inputs optional.

**This GEOSldas PR should be merged once the MAPL tag used by GEOSldas includes the above change.** 

UPDATE 4 Jan 2022: Added change to MAPL v2.15.0 to this PR. 

cc: @mathomp4, @weiyuan-jiang, @biljanaorescanin 