### PR TITLE
Remove GEOSldas version info from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSldas
-  VERSION 17.9
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")


### PR DESCRIPTION
Addresses #513.  Tentatively removing GEOSldas version info from CMakeLists.txt.

The reason for doing this is **not** the burden of maintaining the GEOSldas version info in CMakeLists.txt (although we missed updating the version entry for v17.10.0).  

Rather, the concern is that even if the GEOSldas version info is maintained properly in CMakeLists.txt, in many cases the version info would at best provide a starting point because it cannot reflect changes that users make to GEOSldas before the build. 

Going forward, it may be possible to assemble version info from git as suggested by @tclune:  https://github.com/GEOS-ESM/GEOSldas/issues/513#issuecomment-1015471164

@biljanaorescanin : When you get a chance, please test the PR to make sure we can get away with not having GEOSldas version info in CMakeLists.txt.  If there is a problem, we can restore the version info, set the version to 0.0.0 (something that's obviously bogus), and try again.  

cc: @mathomp4 @weiyuan-jiang 
