### PR TITLE
Added dummy GEOSldas version to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSldas
+  VERSION 0.0.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")


### PR DESCRIPTION
Avoids CMake warning during build.
Follows up on #514.
I think it's safe to merge this without testing.

cc: @tclune @mathomp4 @weiyuan-jiang @biljanaorescanin 