### PR TITLE
Handmerge develop into release/MAPL3 - 2022 Jun 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,44 +1,22 @@
 version: 2.1
 
+# Anchor to prevent forgetting to update a version
+baselibs_version: &baselibs_version v7.3.1
+
 orbs:
-  circleci-tools: geos-esm/circleci-tools@0.13.0
+  ci: geos-esm/circleci-tools@1
 
 workflows:
   build-test:
     jobs:
-      - build-GEOSldas:
+      - ci/build:
           name: build-GEOSldas-on-<< matrix.compiler >>
-          matrix:
-            parameters:
-              compiler: [gfortran, ifort]
           context:
             - docker-hub-creds
-
-jobs:
-  build-GEOSldas:
-    parameters:
-      compiler:
-        type: string
-    executor:
-      name: circleci-tools/<< parameters.compiler >>
-      resource_class: large
-    working_directory: /root/project
-    steps:
-      - checkout:
-          path: GEOSldas
-      - circleci-tools/versions:
-          compiler: << parameters.compiler >>
-      - circleci-tools/mepoclone:
+          matrix:
+            parameters:
+              compiler: [ifort, gfortran]
+          baselibs_version: *baselibs_version
           repo: GEOSldas
-      - circleci-tools/checkout_mapl3_release_branch:
-          repo: GEOSldas
-      - circleci-tools/checkout_if_exists:
-          repo: GEOSldas
-      - circleci-tools/cmake:
-          repo: GEOSldas
-          compiler: << parameters.compiler >>
-      - circleci-tools/buildinstall:
-          repo: GEOSldas
-      - circleci-tools/compress_artifacts
-      - store_artifacts:
-          path: /logfiles
+          mepodevelop: false
+          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.0.0
+  tag: v4.1.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.12.0
+  tag: v3.17.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This is a handmerge of `develop` into `release/MAPL-v3` to make sure the CI for the MAPL 3 release here still works.