### PR TITLE
fix character length in declaration of string variables to avoid truncation of file paths/names

### DIFF
--- a/src/Applications/LDAS_App/preprocess_ldas.F90
+++ b/src/Applications/LDAS_App/preprocess_ldas.F90
@@ -18,30 +18,30 @@ program main
   implicit none
   
   character(len=20 ) :: option
-  character(len=200) :: arg1
-  character(len=200) :: arg2
-  character(len=200) :: arg3
-  character(len=200) :: arg4
-  character(len=200) :: arg5
-  character(len=200) :: arg6
-  character(len=200) :: arg7
+  character(len=512) :: arg1
+  character(len=512) :: arg2
+  character(len=512) :: arg3
+  character(len=512) :: arg4
+  character(len=512) :: arg5
+  character(len=512) :: arg6
+  character(len=512) :: arg7
   
-  character(len=200) :: orig_tile
-  character(len=200) :: new_tile
-  character(len=200) :: domain_def_file
-  character(len=200) :: catch_def_file
-  character(len=200) :: out_path 
-  character(len=200) :: exp_id 
-  character(len=200) :: orig_catch
-  character(len=200) :: new_rtm
-  character(len=200) :: orig_rtm
-  character(len=200) :: new_catch
-  character(len=200) :: orig_BC
-  character(len=200) :: new_BC
-  character(len=200) :: orig_Veg
-  character(len=200) :: new_veg
-  character(len=200) :: orig_ease
-  character(len=200) :: new_ease
+  character(len=512) :: orig_tile
+  character(len=512) :: new_tile
+  character(len=512) :: domain_def_file
+  character(len=512) :: catch_def_file
+  character(len=512) :: out_path 
+  character(len=512) :: exp_id 
+  character(len=512) :: orig_catch
+  character(len=512) :: new_rtm
+  character(len=512) :: orig_rtm
+  character(len=512) :: new_catch
+  character(len=512) :: orig_BC
+  character(len=512) :: new_BC
+  character(len=512) :: orig_Veg
+  character(len=512) :: new_veg
+  character(len=512) :: orig_ease
+  character(len=512) :: new_ease
   character(len=12 ) :: ymdhm
   character(len=12 ) :: SURFLAY
   

--- a/src/Applications/LDAS_App/preprocess_ldas_routines.F90
+++ b/src/Applications/LDAS_App/preprocess_ldas_routines.F90
@@ -118,8 +118,8 @@ contains
     character(*) :: SURFLAY
     
     real :: minlon,maxlon,minlat,maxlat
-    character(len=200):: exclude_file,include_file
-    character(len=300):: bcs_path
+    character(len=512):: exclude_file,include_file
+    character(len=512):: bcs_path
     logical :: file_exist
     logical :: d_exist,c_exist
     
@@ -420,7 +420,7 @@ contains
       
       type(grid_def_type) :: tmp_grid_def
       logical :: c3_grid 
-      character(300) :: fname
+      character(512) :: fname
       
       character(len=*), parameter :: Iam = 'domain_setup'
       character(len=400) :: err_msg
@@ -739,7 +739,7 @@ contains
       
       ! local variables
       
-      character(len=400) :: filename
+      character(len=512) :: filename
       
       integer :: i, istat
       
@@ -1405,7 +1405,7 @@ contains
     subroutine write_cat_param(cat_param, N_catd)
       type(cat_param_type), intent(in) :: cat_param(:)
       integer,intent(in) :: N_catd
-      character(len=300):: fname
+      character(len=512):: fname
       type(date_time_type) :: start_time
       
       integer :: k,n
@@ -1557,7 +1557,7 @@ contains
     character(*), intent(in) :: orig_tile
     character(*), intent(in) :: new_tile
     
-    character(len=200) :: line
+    character(len=256) :: line
     character(len=3)   :: MAPL_Land_STRING
     character(len=4)   :: MAPL_Land_ExcludeFromDomain_STRING
     character(len=400) :: err_msg
@@ -1972,7 +1972,7 @@ contains
     character(*),intent(in) :: new_ease
     logical :: file_exist,is_oldEASE
     integer :: i, N_tile, N_grid
-    character(len=200) :: tmpline
+    character(len=256) :: tmpline
     
     inquire(file=trim(orig_ease),exist=file_exist)
     if( .not. file_exist) stop (" no ease_tile_file")
@@ -2053,8 +2053,8 @@ contains
     integer :: avg_land,n0,local
     integer :: i,s,e,j,k,n1,n2
     logical :: file_exist
-    character(len=100):: tmpLine
-    character(len=100):: gridname
+    character(len=256):: tmpLine
+    character(len=128):: gridname
     real :: rate,rates(60),maxf(60)
     integer :: IMGLOB, JMGLOB
     integer :: face(6),face_land(6)
@@ -2855,8 +2855,9 @@ contains
     logical :: ease_grid
     integer :: typ,k,fid
     
-    character(200) :: tmpline,gridname
-    character(300) :: fname
+    character(256) :: tmpline
+    character(128) :: gridname
+    character(512) :: fname
 
     character(len=*), parameter :: Iam = 'LDAS_read_til_file'
 

--- a/src/Applications/LDAS_App/tile_bin2nc4.F90
+++ b/src/Applications/LDAS_App/tile_bin2nc4.F90
@@ -5,12 +5,11 @@ PROGRAM tile_bin2nc4
 
   integer       :: i,k,  n, NTILES
   integer       :: NCFOutID, Vid, STATUS, CellID, TimID, nVars
-  character*256 :: Usage="tile_bin2nc4.x BINFILE DESCRIPTOR TILECOORD"
-  character*256 :: BINFILE, TILECOORD, DESCRIPTOR, arg(3)
-  character*100 :: MYNAME, BUF
+  character(256) :: Usage="tile_bin2nc4.x BINFILE DESCRIPTOR TILECOORD"
+  character(512) :: BINFILE, TILECOORD, DESCRIPTOR, arg(3)
+  character(128) :: MYNAME, BUF
   integer, dimension(8)               :: date_time_values
   character (22)                      :: time_stamp
-  character*100                       :: Str_Atr
   real, allocatable, dimension (:)    :: lons, lats, var
   integer, allocatable, dimension (:) :: tileid, i_index, j_index 
   integer       :: myunit1, myunit2
@@ -189,7 +188,7 @@ PROGRAM tile_bin2nc4
 
     character(*), intent(in)           :: SHORT_NAME
     integer, intent (in), optional     :: LNAME, UNT
-    character(100)                     :: str_atr, LONG_NAME, UNITS
+    character(128)                     :: str_atr, LONG_NAME, UNITS
 
     SELECT case (trim(SHORT_NAME))
 

--- a/src/Applications/LDAS_App/util/inputs/mwRTM_params/mwrtm_bin2nc4.F90
+++ b/src/Applications/LDAS_App/util/inputs/mwRTM_params/mwrtm_bin2nc4.F90
@@ -12,7 +12,7 @@ PROGRAM mwrtm_bin2nc4
   implicit none
   INCLUDE 'netcdf.inc'
 
-  integer       :: i,k,  n, iargc, NTILES
+  integer       :: i,k,  n, command_argument_count, NTILES
   integer       :: NCFOutID, Vid, STATUS, CellID, TimID, nVars
   character(512):: Usage="mwrtm_bin2nc4.x mwrtm_BINFILE  mwRTM_param.nc4"
   character(512):: BINFILE, MWRTMNC4, arg(3)
@@ -46,7 +46,7 @@ PROGRAM mwrtm_bin2nc4
        'MWRTM_LEWT     ']
   
   ! processing command line agruments
-  I = iargc()
+  I = command_argument_count()
   
   if( I /=2 ) then
      print *, "Wrong Number of arguments: ", i
@@ -55,7 +55,7 @@ PROGRAM mwrtm_bin2nc4
   end if
 
   do n=1,I
-     call getarg(n,arg(n))
+     call get_command_argument(n,arg(n))
   enddo
 
   read(arg(1),'(a)') BINFILE

--- a/src/Applications/LDAS_App/util/inputs/mwRTM_params/mwrtm_bin2nc4.F90
+++ b/src/Applications/LDAS_App/util/inputs/mwRTM_params/mwrtm_bin2nc4.F90
@@ -14,10 +14,8 @@ PROGRAM mwrtm_bin2nc4
 
   integer       :: i,k,  n, iargc, NTILES
   integer       :: NCFOutID, Vid, STATUS, CellID, TimID, nVars
-  character*256 :: Usage="mwrtm_bin2nc4.x mwrtm_BINFILE  mwRTM_param.nc4"
-  character*256 :: BINFILE, MWRTMNC4, arg(3)
-  character*100 :: MYNAME
-  character*100                       :: Str_Atr
+  character(512):: Usage="mwrtm_bin2nc4.x mwrtm_BINFILE  mwRTM_param.nc4"
+  character(512):: BINFILE, MWRTMNC4, arg(3)
   real, allocatable, dimension (:)    :: var
   integer, allocatable,dimension (:)  :: NT
   character(len=:),allocatable :: shnms(:)
@@ -60,11 +58,9 @@ PROGRAM mwrtm_bin2nc4
      call getarg(n,arg(n))
   enddo
 
-  call getenv ("MYNAME"        ,MYNAME        )
   read(arg(1),'(a)') BINFILE
   read(arg(2),'(a)') MWRTMNC4
 
-  print *,MYNAME
   print *,trim(BINFILE)
   print *,trim(MWRTMNC4)
 
@@ -212,7 +208,7 @@ PROGRAM mwrtm_bin2nc4
 
     character(*), intent(in)           :: SHORT_NAME
     integer, intent (in), optional     :: LNAME, UNT
-    character(100)                     :: str_atr, LONG_NAME, UNITS
+    character(128)                     :: str_atr, LONG_NAME, UNITS
 
     SELECT case (trim(SHORT_NAME))
     case('MWRTM_VEGCLS');    LONG_NAME = 'L-band RTM model: Vegetation class. Type is Unsigned32';             UNITS = '1'


### PR DESCRIPTION
Increase the character length of string variables for path/file names to avoid truncation.  Before this fix, there were sometimes runtime errors when path/file names got too long. 
The present PR anticipates and requires merging of #569.
The present PR replaces #572, which was on top of "develop" before the #569 merge and would not have preserved some changes because one of the changed utility script was moved.
#572 was tested by @weiyuan-jiang.