### PR TITLE
Update to MAPL 2.25.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.23.1
+  tag: v2.25.0
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
Closes #577 

This PR updates MAPL to v2.25.0. This is needed to support GEOSgcm_GridComp `develop` which pulled in a PR needing a newer MAPL (https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/623)