### PR TITLE
Update to ESMA_env 4.4.0 and ESMA_cmake v3.18.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# Global Editor Config for MAPL
+#
+# This is an ini style configuration. See http://editorconfig.org/ for more information on this file.
+#
+# Top level editor config.
+root = true
+
+# Always use Unix style new lines with new line ending on every file and trim whitespace
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Python: PEP8 defines 4 spaces for indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# YAML format, 2 spaces
+[{*.yaml,*.yml}]
+indent_style = space
+indent_size = 2
+
+# CMake (from KitWare: https://github.com/Kitware/CMake/blob/master/.editorconfig)
+[{CMakeLists.txt,*.cmake,*.rst}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,14 @@
 /@env/
 /env/
 /env@/
-/BUILD/
-/build*/
-/install*/
 /.mepo/
 parallel_build.o*
 log.*
 CMakeUserPresets.json
+
+*.swp
+*.swo
+.DS_Store
+*#
+.#*
+**/CVS/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,143 @@
+﻿{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base-configure",
+      "hidden": true,
+      "displayName": "Base Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "cacheVariables": {
+        "BASEDIR": "$env{BASEDIR}",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}"
+      }
+    },
+    {
+      "name": "base-gnu",
+      "hidden": true,
+      "inherits": "base-configure",
+      "displayName": "Base GNU Make Config",
+      "description": "Sets GNU Make generator",
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "base-ninja",
+      "hidden": true,
+      "inherits": "base-configure",
+      "displayName": "Base Ninja Config",
+      "description": "Sets Ninja generator",
+      "generator": "Ninja"
+    },
+    {
+      "name": "Release",
+      "inherits": "base-gnu",
+      "displayName": "Release Configure",
+      "description": "Release build using GNU Make generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "Debug",
+      "inherits": "base-gnu",
+      "displayName": "Debug Configure",
+      "description": "Debug build using GNU Make generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "Aggressive",
+      "inherits": "base-gnu",
+      "displayName": "Aggressive Configure",
+      "description": "Aggressive build using GNU Make generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Aggressive"
+      }
+    },
+    {
+      "name": "Release-Ninja",
+      "inherits": "base-ninja",
+      "displayName": "Release Ninja Configure",
+      "description": "Release build using Ninja generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "Debug-Ninja",
+      "inherits": "base-ninja",
+      "displayName": "Debug Ninja Configure",
+      "description": "Debug build using Ninja generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "Aggressive-Ninja",
+      "inherits": "base-ninja",
+      "displayName": "Aggressive Ninja Configure",
+      "description": "Aggressive build using Ninja generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Aggressive"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base-build",
+      "hidden": true,
+      "displayName": "Base Build Config",
+      "description": "Sets default build options",
+      "jobs": 6,
+      "targets": ["install"]
+    },
+    {
+      "name": "Release",
+      "configurePreset": "Release",
+      "inherits": "base-build",
+      "displayName": "Release Build",
+      "description": "Release build using GNU Make generator"
+    },
+    {
+      "name": "Debug",
+      "configurePreset": "Debug",
+      "inherits": "base-build",
+      "displayName": "Debug Build",
+      "description": "Debug build using GNU Make generator"
+    },
+    {
+      "name": "Aggressive",
+      "configurePreset": "Aggressive",
+      "inherits": "base-build",
+      "displayName": "Aggressive Build",
+      "description": "Aggressive build using GNU Make generator"
+    },
+    {
+      "name": "Release-Ninja",
+      "configurePreset": "Release-Ninja",
+      "inherits": "base-build",
+      "displayName": "Release Ninja Build",
+      "description": "Release build using Ninja generator"
+    },
+    {
+      "name": "Debug-Ninja",
+      "configurePreset": "Debug-Ninja",
+      "inherits": "base-build",
+      "displayName": "Debug Ninja Build",
+      "description": "Debug build using Ninja generator"
+    },
+    {
+      "name": "Aggressive-Ninja",
+      "configurePreset": "Aggressive-Ninja",
+      "inherits": "base-build",
+      "displayName": "Aggressive Ninja Build",
+      "description": "Aggressive build using Ninja generator"
+    }
+  ]
+}

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.2.0
+  tag: v4.4.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.17.0
+  tag: v3.18.0
   develop: develop
 
 ecbuild:
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.23.1
+  tag: v2.25.0
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
Keeping this PR draft until it can be tested by @biljanaorescanin or @gmao-rreichle 

ETA: Note that this also contains the MAPL 2.25.0 update that's in #578. But I figure that will get in first, so no need to mention it here.

---

This PR is to move GEOSldas to be "in sync" with GEOSgcm v10.22.6. The changes are:

* ESMA_env v4.2.0 → v4.4.0 (Move to Intel 2022.1, Updates for TOSS4 at NAS)
* ESMA_cmake v3.17.0 → v3.18.0 (CPack updates, possible support for Apple M2)
* Add `CMakePresets.json`
* Add `.editorconfig`
* Add common Vim and EMACS temp files to `.gitignore`

Of all these changes, only the update to Intel 2022.1 could possibly cause an issue. Now, I know GEOSldas will *build* with Intel 2022.1 because, well, the CI tests now use it by default. But, I don't know if it is zero-diff. I'm fairly hopeful it will be because it was for GEOSgcm, but we won't know until it is tested. As such, I am not labeling it as **either** 0-diff or non-0-diff.

Everything else is really not too important. LDAS doesn't run at NAS, so TOSS4 support is moot. The CPack stuff isn't used in the LDAS, so the ESMA_cmake is just "keep up to date". 

The other three changes are also pretty trivial. 

`CMakePresets.json` is a [weird/new CMake way of building things](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) that I'm fiddling with. You sort of have to know how to use it, so for most people it's something to ignore. (But, I have some automated things I like to use that sort of expect that file to be around.)

The `.gitignore` update is to ignore some temp files from vim and emacs. Just to be sure they don't get committed!

The `.editorconfig` file is something I'm fine with removing or changing if @gmao-rreichle wants me to. It is based on [EditorConfig](https://editorconfig.org/) which some editors will obey to try and keep files "consistent" in style. For example, the one here says:

* For CMake files, use a 2-space indent
* For YAML files, 2-space indent
* For Python files, 4-space indent (per PEP8)
* Strip out trailing whitespace

For most editors (vim, emacs, etc.) you [need a plugin](https://editorconfig.org/#download) to enable the editor to follow this file, so this doesn't affect much unless you ask your editor to do so. I use this `.editorconfig` in GEOSgcm and MAPL and other places just to try to keep things consistent for myself, I suppose.