### PR TITLE
Bug fix: Make "lenkf.j -debug" work (again)

### DIFF
--- a/src/Applications/LDAS_App/lenkf.j.template
+++ b/src/Applications/LDAS_App/lenkf.j.template
@@ -34,7 +34,7 @@ unsetenv LD_LIBRARY_PATH
 if ( "$1" == "-debug" ) then
   set debug_flag = 1
 endif
-unsetenv argv
+unset argv
 setenv argv
 
 source $GEOSBIN/g5_modules

--- a/src/Applications/LDAS_App/lenkf.j.template
+++ b/src/Applications/LDAS_App/lenkf.j.template
@@ -30,6 +30,13 @@ setenv ESMADIR    $EXPDIR/build/
 setenv GEOSBIN    $ESMADIR/bin/
 # need to unsetenv LD_LIBRARY_PATH for execution of LDAS within the coupled land-atm DAS
 unsetenv LD_LIBRARY_PATH
+
+if ( "$1" == "-debug" ) then
+  set debug_flag = 1
+endif
+unsetenv argv
+setenv argv
+
 source $GEOSBIN/g5_modules
 
 setenv I_MPI_DAPL_UD enable
@@ -371,7 +378,7 @@ while ( $counter <= ${NUM_SGMT} )
 
    # Debugging
    # ---------
-   if ( "$1" == "-debug" ) then
+   if ( $debug_flag == 1 ) then
       echo ""
       echo "------------------------------------------------------------------"
       echo ""

--- a/src/Applications/LDAS_App/process_hist.csh
+++ b/src/Applications/LDAS_App/process_hist.csh
@@ -53,7 +53,7 @@ endif
 
 if($NENS > 1) then
    set GridComp = ENSAVG
-   sed -i 's|VEGDYN|'VEGDYN0000'|g' $HISTRC
+   sed -i 's|VEGDYN|'VEGDYN_e0000'|g' $HISTRC
 #   sed -i 's|DATAATM|'DATAATM0000'|g' $HISTRC
 endif
 

--- a/src/Applications/LDAS_App/process_hist.csh
+++ b/src/Applications/LDAS_App/process_hist.csh
@@ -53,7 +53,7 @@ endif
 
 if($NENS > 1) then
    set GridComp = ENSAVG
-   sed -i 's|VEGDYN|'VEGDYN_e0000'|g' $HISTRC
+   sed -i 's|VEGDYN|'VEGDYN0000'|g' $HISTRC
 #   sed -i 's|DATAATM|'DATAATM0000'|g' $HISTRC
 endif
 


### PR DESCRIPTION
pass on debug option through command line
When "lenkf.j -debug" was run at the command line, somehow the arguments or environment conflicted with the "source g5_modules" call within lenkf.j.  This PR fixes the problem.