### PR TITLE
new MAPL tag for GEOSldas 

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.29.0
+  tag: v2.XX.X
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.XX.X
+  tag: v2.31.0
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
We will need new MAPL tag after we merge Snow Albedo [PR#618](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/618)
Currently just a dummy placeholder for MAPL