### PR TITLE
Update to MAPL 2.33, components and CI to use Baselibs 7.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchor to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.5.0
+baselibs_version: &baselibs_version v7.7.0
 
 orbs:
   ci: geos-esm/circleci-tools@1

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.31.0
+  tag: v2.32.0
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.32.0
+  tag: v2.33.0
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -5,19 +5,19 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.4.0
+  tag: v4.8.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.18.0
+  tag: v3.21.0
   develop: develop
 
 ecbuild:
   local: ./@cmake/@ecbuild
   remote: ../ecbuild.git
-  tag: geos/v1.2.0
+  tag: geos/v1.3.0
 
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared


### PR DESCRIPTION
This PR updates the `components.yaml` to match that of GEOSgcm `main`. It mainly updates Baselibs to 7.7.0 and some minor other changes to CMake macros and flags for GNU in odd places (running x86_64 on an M1).

The CI is also bumped to Baselibs 7.7.0.

After a comment from @gmao-rreichle, might as well bump up to MAPL 2.32.0 and save @biljanaorescanin two tests. Do them in one!

ETA: Now with MAPL 2.33 which has bug fixes for GNU with ExtData2G (which might not matter to the ldas??)
