### PR TITLE
Update to MAPL 2.34.1, ESMA_cmake 3.24.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.21.0
+  tag: v3.24.0
   develop: develop
 
 ecbuild:
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.33.0
+  tag: v2.34.1
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
This PR updates GEOSldas to use MAPL 2.34.1. The impetus for this is the that we discovered a bug in how MAPL handled 4D variables in restarts when `WRITE_RESTART_BY_OSERVER: YES` was set. Now in GEOSgcm this is automatically set when Open MPI is the MPI stack (which is true for GNU at NCCS). I'm not sure if the LDAS uses that setting (@weiyuan-jiang might know).

I also don't know if the LDAS has any 4D variables in its restarts, but it is possible if there are 2 ungridded dims in a variable (since I assume 🤷🏼 that the LDAS is mainly 2d variables discounting ungridded dims).

Also, this will bring in MAPL 2.34.0 changes as well. Per [the release notes](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.34.0), I don't think anything in 2.34 directly affects the LDAS, so I'll mark this as zero-diff, but @biljanaorescanin will of course test.

Also also, I'm updating ESMA_cmake to 3.24.0. Per [the changelog](https://github.com/GEOS-ESM/ESMA_cmake/blob/main/CHANGELOG.md), this is very minor.