### PR TITLE
mv GEOS_Util to a separate repository

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -26,6 +26,12 @@ GMAO_Shared:
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
+GMAO_Util:
+  local: ./src/Shared/@GEOS_Util
+  remote: ../GEOS_Util.git
+  branch: main
+  develop: main
+
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,2 +1,3 @@
 esma_add_subdirectory (MAPL)
 esma_add_subdirectory (GMAO_Shared)
+esma_add_subdirectory (GEOS_Util)


### PR DESCRIPTION
GEOS_Util is moved out of GMAO_Shared. GEOSldas follows that changes