### PR TITLE
update legacy bcs path

### DIFF
--- a/doc/README.MetForcing_and_BCS.md
+++ b/doc/README.MetForcing_and_BCS.md
@@ -329,9 +329,9 @@ COMMONLY USED boundary conditions (bcs):
 
 #### MERRA2
 ```
-  BCS_PATH : /discover/nobackup/ltakacs/bcs/Ganymed-4_0/Ganymed-4_0_MERRA-2/
+  BCS_PATH : /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Ganymed-4_0/Ganymed-4_0_MERRA-2/
 ```
-  Note: The same land bcs (for cube-shere only) are also in /discover/nobackup/ltakacs/bcs/Icarus/Icarus_MERRA-2/
+  Note: The same land bcs (for cube-shere only) are also in /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus/Icarus_MERRA-2/
 
 
 #### SMAP Nature Run v03
@@ -351,7 +351,7 @@ COMMONLY USED boundary conditions (bcs):
 
 #### Icarus-NL ("New Land"), SMAP_Nature_v7.2
 ```
-  BCS_PATH : /discover/nobackup/ltakacs/bcs/Icarus-NL/Icarus-NL_[XXXX]/
+  BCS_PATH : /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NL/Icarus-NL_[XXXX]/
 ```
 
 Notes:
@@ -361,7 +361,7 @@ Notes:
 
 #### Icarus-NLv2, SMAP L4_SM Version 4
 ```
-  BCS_PATH : /discover/nobackup/ltakacs/bcs/Icarus-NLv2/Icarus-NLv2_[XXXX]/
+  BCS_PATH : /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NLv2/Icarus-NLv2_[XXXX]/
 ```
 
 Notes: 
@@ -370,7 +370,7 @@ Notes:
 	
 #### Icarus-NLv3, SMAP_Nature_v8.1
 ```
-  BCS_PATH : /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_[XXXX]/
+  BCS_PATH : /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NLv3/Icarus-NLv3_[XXXX]/
 ```
 
 Notes: 

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -407,11 +407,11 @@ class LDASsetup:
               elif (self.catch == 'catchcnclm40'):
                 self.in_rstfile  = '/discover/nobackup/projects/gmao/ssd/land/l_data/LandRestarts_for_Regridding' \
                                    '/CatchCN/M36/20150301_0000/catchcnclm40_internal_dummy' 
-                self.in_tilefile = '/discover/nobackup/ltakacs/bcs/Heracles-NL/SMAP_EASEv2_M36/SMAP_EASEv2_M36_964x406.til'
+                self.in_tilefile = '/discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Heracles-NL/SMAP_EASEv2_M36/SMAP_EASEv2_M36_964x406.til'
               elif (self.catch == 'catchcnclm45'):
                 self.in_rstfile  = '/discover/nobackup/projects/gmao/ssd/land/l_data/LandRestarts_for_Regridding' \
                                    '/CatchCN/M36/19800101_0000/catchcnclm45_internal_dummy'
-                self.in_tilefile = '/discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_EASE/SMAP_EASEv2_M36/SMAP_EASEv2_M36_964x406.til'
+                self.in_tilefile = '/discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NLv3/Icarus-NLv3_EASE/SMAP_EASEv2_M36/SMAP_EASEv2_M36_964x406.til'
               else:
                 sys.exit('need to provide at least dummy files')
                 self.in_rstfile = None

--- a/src/Applications/LDAS_App/process_rst.py
+++ b/src/Applications/LDAS_App/process_rst.py
@@ -16,7 +16,7 @@ def remap_config_ldas(config, RESTART_str, RESTART_PATH, RESTART_ID):
      config['input']['shared'] = merra2_expid(config['input']['shared'])
      config['input']['shared']['rst_dir'] = out_dir+ '/merra2_tmp_'+ yyyymmddhh
      config['input']['surface']['wemin'] = 26
-     config['input']['shared']['bcs_dir'] = '/discover/nobackup/ltakacs/bcs/Ganymed-4_0/Ganymed-4_0_MERRA-2/CF0180x6C_DE1440xPE0720/'
+     config['input']['shared']['bcs_dir'] = '/discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Ganymed-4_0/Ganymed-4_0_MERRA-2/CF0180x6C_DE1440xPE0720/'
      
    if RESTART_str == "G" :
      # WY note: it is a bad idea to overload restart_path and restart_id
@@ -39,7 +39,7 @@ def remap_config_ldas(config, RESTART_str, RESTART_PATH, RESTART_ID):
        print( "          Please select RESTART: M and use MERRA-2, instead.")
        sys.exit(1)
 
-     config['input']['shared']['bcs_dir'] = '/discover/nobackup/ltakacs/bcs/Icarus/Icarus_Ostia/CF0720x6C_CF0720x6C/'
+     config['input']['shared']['bcs_dir'] = '/discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus/Icarus_Ostia/CF0720x6C_CF0720x6C/'
      config['input']['surface']['wemin'] = 26
      config['input']['shared']['rst_dir'] = out_dir+'/InData'+ '/'
      suffix = '_21z.tar'
@@ -47,7 +47,7 @@ def remap_config_ldas(config, RESTART_str, RESTART_PATH, RESTART_ID):
      if ((date_16 <= expdate) and (expdate < date_17)):
         fpver = 'GEOS-5.16/GEOSadas-5_16/'
         fplab = 'f516_fp'
-        config['input']['shared']['bcs_dir'] = '/discover/nobackup/ltakacs/bcs/Ganymed-4_0/Ganymed-4_0_Ostia/CF0720x6C_DE2880xPE1440/'
+        config['input']['shared']['bcs_dir'] = '/discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Ganymed-4_0/Ganymed-4_0_Ostia/CF0720x6C_DE2880xPE1440/'
         suffix = '_21z.bin'
 
      if ((date_17 <= expdate) and (expdate < date_21)):


### PR DESCRIPTION
This PR updates the path to the legacy bcs data by pointing to the new "bcs_shared" directory in the GMAO project space on Discover (replacing /discover/nobackup/ltakacs/bcs/).

This is the first step in using (legacy) bcs from the new "bcs_shared" dir.  The next and much more complex step will address using bcs in their revised sub-directory structure.