### PR TITLE
clean up variable and subroutine names for Ldas grid 

### DIFF
--- a/src/Applications/LDAS_App/preprocess_ldas_routines.F90
+++ b/src/Applications/LDAS_App/preprocess_ldas_routines.F90
@@ -3027,9 +3027,9 @@ contains
     N_tile_land=i
     allocate(tile_coord_land(N_tile_land))
     tile_coord_land=tile_coord(1:N_tile_land)
-    ! hash_[x]_indg is not written into the tile_coord file and not needed in preprocessing
-    tile_coord_land%hash_i_indg = nint(nodata_generic)
-    tile_coord_land%hash_j_indg = nint(nodata_generic)
+    ! pert_[x]_indg is not written into the tile_coord file and not needed in preprocessing
+    tile_coord_land%pert_i_indg = nint(nodata_generic)
+    tile_coord_land%pert_j_indg = nint(nodata_generic)
     if(present(f2g)) then
        allocate(f2g(fid))
        f2g = f2g_tmp(1:fid)

--- a/src/Applications/LDAS_App/preprocess_ldas_routines.F90
+++ b/src/Applications/LDAS_App/preprocess_ldas_routines.F90
@@ -46,7 +46,7 @@ module preprocess_ldas_routines
   
   use LDAS_TileCoordRoutines,          ONLY:   &
        LDAS_create_grid_g,                     &
-       get_minimum_grid,                          &
+       get_minExtent_grid,                     &
        io_domain_files
   
   use nr_ran2_gasdev,                  ONLY:   &
@@ -537,8 +537,8 @@ contains
          !  determine smallest subgrid of tile_grid_d that contains all
          !  catchments/tiles in domain
          
-         tile_grid_d = get_minimum_grid( N_cat_domain, tile_coord%i_indg, tile_coord%j_indg,  &
-              tile_coord%min_lon, tile_coord%min_lat, tile_coord%max_lon, tile_coord%max_lat, &
+         tile_grid_d = get_minExtent_grid( N_cat_domain, tile_coord%i_indg, tile_coord%j_indg, &
+              tile_coord%min_lon, tile_coord%min_lat, tile_coord%max_lon, tile_coord%max_lat,  &
               tile_grid_g) 
          
          ! output domain files

--- a/src/Applications/LDAS_App/preprocess_ldas_routines.F90
+++ b/src/Applications/LDAS_App/preprocess_ldas_routines.F90
@@ -46,7 +46,7 @@ module preprocess_ldas_routines
   
   use LDAS_TileCoordRoutines,          ONLY:   &
        LDAS_create_grid_g,                     &
-       get_tile_grid,                          &
+       get_minimum_grid,                          &
        io_domain_files
   
   use nr_ran2_gasdev,                  ONLY:   &
@@ -537,9 +537,9 @@ contains
          !  determine smallest subgrid of tile_grid_d that contains all
          !  catchments/tiles in domain
          
-         call get_tile_grid( N_cat_domain, tile_coord%i_indg, tile_coord%j_indg,              &
+         tile_grid_d = get_minimum_grid( N_cat_domain, tile_coord%i_indg, tile_coord%j_indg,  &
               tile_coord%min_lon, tile_coord%min_lat, tile_coord%max_lon, tile_coord%max_lat, &
-              tile_grid_g, tile_grid_d) 
+              tile_grid_g) 
          
          ! output domain files
          

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -636,8 +636,6 @@ contains
           pert_grid_f = get_minExtent_grid(N_catf, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, &
                tile_coord_f%min_lon, tile_coord_f%min_lat, tile_coord_f%max_lon, tile_coord_f%max_lat, &
                pert_grid_g)
-            
-       else
        endif
     endif
     

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -632,11 +632,6 @@ contains
        !  cube-sphere               !  lat/lon grid of resolution similar to that of (cube-sphere) tile_grid
        
        pert_grid_g = get_pert_grid(tile_grid_g)
-       ! pert_grid_f = get_pert_grid(tile_grid_f) -- SEEMS REDUNDANT, OVERWRITTEN BELOW: pert_grid_f = get_minExtent_grid()
-       
-       !if(trim(grid_type) == "Cubed-Sphere" ) then
-       !
-       !   _ASSERT(index(tile_grid_g%gridtype, 'c3') /=0, "tile_grid_g does not describe a cubed-sphere grid")
        
        if ( .not. (pert_grid_g==tile_grid_g) ) then
 
@@ -668,10 +663,7 @@ contains
     call MPI_BCAST(tile_coord_f,N_catf,    MPI_tile_coord_type,0,mpicomm, mpierr)
     call MPI_BCAST(pert_grid_g, 1,         MPI_grid_def_type,  0,mpicomm, mpierr)
     call MPI_BCAST(pert_grid_f, 1,         MPI_grid_def_type,  0,mpicomm, mpierr)
-    
-    !if(trim(grid_type) == "Cubed-Sphere" ) then
     call MPI_BCAST(tile_grid_g, 1,         MPI_grid_def_type,  0,mpicomm, mpierr)
-    !endif
 
     block
       integer, allocatable :: f2tile_id(:), tile_id2f(:)
@@ -711,11 +703,7 @@ contains
     tcinternal%pgrid_g = pert_grid_g
     tcinternal%pgrid_f = pert_grid_f
     tcinternal%pgrid_l = pert_grid_l
-    !if(trim(grid_type) == "Cubed-Sphere" ) then
     tcinternal%tgrid_g = tile_grid_g
-    !else
-    !  tcinternal%grid_g = tcinternal%pgrid_g
-    !endif
 
     do i = 1, NUM_ENSEMBLE
        call MAPL_GetObjectFromGC(gcs(METFORCE(i)), CHILD_MAPL, rc=status)

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -18,7 +18,7 @@ module GEOS_LdasGridCompMod
   use EASE_conv, only: ease_inverse
   use LDAS_TileCoordType, only: tile_coord_type , T_TILECOORD_STATE, TILECOORD_WRAP
   use LDAS_TileCoordType, only: grid_def_type, io_grid_def_type
-  use LDAS_TileCoordRoutines, only: get_minimum_grid, get_ij_ind_from_latlon, io_domain_files
+  use LDAS_TileCoordRoutines, only: get_minExtent_grid, get_ij_ind_from_latlon, io_domain_files
   use LDAS_ConvertMod, only: esmf2ldas
   use LDAS_PertRoutinesMod, only: get_pert_grid
   use LDAS_ensdrv_functions,ONLY:  get_io_filename 
@@ -633,7 +633,7 @@ contains
               tile_coord_f(i)%hash_i_indg,tile_coord_f(i)%hash_j_indg)
           enddo
           !2) re-generate pert_grid_f in Lat-Lon
-          pert_grid_f = get_minimum_grid(N_catf, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
+          pert_grid_f = get_minExtent_grid(N_catf, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, &
                tile_coord_f%min_lon, tile_coord_f%min_lat, tile_coord_f%max_lon, tile_coord_f%max_lat, &
                pert_grid_g)
             
@@ -677,7 +677,7 @@ contains
 
     allocate(tcinternal%tile_coord_f,source = tile_coord_f)
     
-     pert_grid_l = get_minimum_grid(land_nt_local,                               &
+     pert_grid_l = get_minExtent_grid(land_nt_local,                             &
          tcinternal%tile_coord%hash_i_indg, tcinternal%tile_coord%hash_j_indg,   &
          tcinternal%tile_coord%min_lon,     tcinternal%tile_coord%min_lat,       &
          tcinternal%tile_coord%max_lon,     tcinternal%tile_coord%max_lat,       &

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -17,7 +17,7 @@ module GEOS_LdasGridCompMod
 
   use EASE_conv, only: ease_inverse
   use LDAS_TileCoordType, only: tile_coord_type , T_TILECOORD_STATE, TILECOORD_WRAP
-  use LDAS_TileCoordType, only: grid_def_type, io_grid_def_type
+  use LDAS_TileCoordType, only: grid_def_type, io_grid_def_type, operator (==)
   use LDAS_TileCoordRoutines, only: get_minExtent_grid, get_ij_ind_from_latlon, io_domain_files
   use LDAS_ConvertMod, only: esmf2ldas
   use LDAS_PertRoutinesMod, only: get_pert_grid

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -654,7 +654,9 @@ contains
 
        else
           
-          ! do nothing because %pert_i_indg and %pert_j_indg were initialized to %i_indg and %j_indg
+          pert_grid_f = tile_grid_f
+
+          ! note that %pert_i_indg and %pert_j_indg were initialized to %i_indg and %j_indg
           !   in io_tile_coord_type() when tile_coord was read via io_domain_files()
           
        endif

--- a/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOS_LdasGridComp.F90
@@ -18,7 +18,7 @@ module GEOS_LdasGridCompMod
   use EASE_conv, only: ease_inverse
   use LDAS_TileCoordType, only: tile_coord_type , T_TILECOORD_STATE, TILECOORD_WRAP
   use LDAS_TileCoordType, only: grid_def_type, io_grid_def_type
-  use LDAS_TileCoordRoutines, only: get_tile_grid, get_ij_ind_from_latlon, io_domain_files
+  use LDAS_TileCoordRoutines, only: get_minimum_grid, get_ij_ind_from_latlon, io_domain_files
   use LDAS_ConvertMod, only: esmf2ldas
   use LDAS_PertRoutinesMod, only: get_pert_grid
   use LDAS_ensdrv_functions,ONLY:  get_io_filename 
@@ -620,24 +620,24 @@ contains
        close(10)
        call io_grid_def_type('w', logunit, tile_grid_f, 'tile_grid_f')
 
-       call get_pert_grid(tile_grid_g, pert_grid_g)
+       pert_grid_g = get_pert_grid(tile_grid_g)
+       pert_grid_f = get_pert_grid(tile_grid_f)
+
        if(trim(grid_type) == "Cubed-Sphere" ) then
 
           _ASSERT(index(tile_grid_g%gridtype, 'c3') /=0, "tile_grid_g does not describe a cubed-sphere grid")
          
-          !1) generate a lat-lon grid for landpert and land assim ( 4*N_lonX3*N_lon)
-          !2) get hash index
+          !1) get hash index for cubed-sphere
           do i = 1, N_catf
              call get_ij_ind_from_latlon(pert_grid_g,tile_coord_f(i)%com_lat,tile_coord_f(i)%com_lon, &
               tile_coord_f(i)%hash_i_indg,tile_coord_f(i)%hash_j_indg)
           enddo
-          !3) re-generate tile_grid_f in Lat-Lon
-          call get_tile_grid(N_catf, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
+          !2) re-generate pert_grid_f in Lat-Lon
+          pert_grid_f = get_minimum_grid(N_catf, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
                tile_coord_f%min_lon, tile_coord_f%min_lat, tile_coord_f%max_lon, tile_coord_f%max_lat, &
-               pert_grid_g, pert_grid_f)
+               pert_grid_g)
             
        else
-          call get_pert_grid(tile_grid_f, pert_grid_f)
        endif
     endif
     
@@ -677,11 +677,11 @@ contains
 
     allocate(tcinternal%tile_coord_f,source = tile_coord_f)
     
-    call get_tile_grid(land_nt_local,                                            &
+     pert_grid_l = get_minimum_grid(land_nt_local,                               &
          tcinternal%tile_coord%hash_i_indg, tcinternal%tile_coord%hash_j_indg,   &
          tcinternal%tile_coord%min_lon,     tcinternal%tile_coord%min_lat,       &
          tcinternal%tile_coord%max_lon,     tcinternal%tile_coord%max_lat,       &
-         pert_grid_g, pert_grid_l)
+         pert_grid_g)
    
 
     tcinternal%pgrid_g = pert_grid_g

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1841,7 +1841,7 @@ contains
          trim(out_path), trim(exp_id), exp_domain,                         &
          met_force, lai, cat_param, mwRTM_param,                           &
          tile_coord_l, tile_coord_rf,                                      &
-         tcinternal%pgrid_f, tcinternal%pgrid_g,                           &
+         tcinternal%pgrid_f, tcinternal%pgrid_g, tcinternal%grid_g,        &
          N_catl_vec, low_ind, l2rf, rf2l,                                  &
          N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
          update_type,                                                      &
@@ -1957,7 +1957,7 @@ contains
        if (out_smapL4SMaup)                                                        &
             call write_smapL4SMaup( 'analysis', date_time_new, trim(out_path),     &
             trim(exp_id), NUM_ENSEMBLE, N_catl, N_catf, N_obsl, tile_coord_rf,     &
-            tcinternal%pgrid_g, N_catl_vec, low_ind,                                &
+            tcinternal%grid_g, N_catl_vec, low_ind,                                &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn   )
 
     end if ! end if (.true.)

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1078,8 +1078,6 @@ contains
     ! mapping f to re-orderd f so it is continous for mpi_gather
     ! rf -- ordered by processors. Within the processor, ordered by MAPL grid
     integer, allocatable :: f2rf(:) ! mapping re-orderd rf to f for the LDASsa output
-    type(grid_def_type)  :: tile_grid_g
-    type(grid_def_type)  :: tile_grid_f
     character(len=300)   :: seed_fname
     character(len=300)   :: fname_tpl
     character(len=14)    :: datestamp
@@ -1842,8 +1840,8 @@ contains
          NUM_ENSEMBLE, N_catl, N_catf, N_obsl_max,                         &
          trim(out_path), trim(exp_id), exp_domain,                         &
          met_force, lai, cat_param, mwRTM_param,                           &
-         tile_coord_l, tile_coord_rf, tcinternal%grid_f,                   &
-         tcinternal%grid_f, tcinternal%grid_l, tcinternal%grid_g,          &
+         tile_coord_l, tile_coord_rf, tcinternal%pgrid_f,                   &
+         tcinternal%pgrid_f, tcinternal%pgrid_l, tcinternal%pgrid_g,          &
          N_catl_vec, low_ind, l2rf, rf2l,                                  &
          N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
          update_type,                                                      &
@@ -1880,7 +1878,7 @@ contains
             date_time_new, trim(out_path), trim(exp_id),                 &
             N_obsl, N_obs_param, NUM_ENSEMBLE,                           &
             N_catl, tile_coord_l,                                        &
-            N_catf, tile_coord_rf, tcinternal%grid_f, tcinternal%grid_g, &
+            N_catf, tile_coord_rf, tcinternal%pgrid_f, tcinternal%pgrid_g, &
             N_catl_vec, low_ind, rf2l, N_catg, rf2g,                     &
             obs_param,                                                   &
             met_force, lai,                                              &
@@ -1959,7 +1957,7 @@ contains
        if (out_smapL4SMaup)                                                        &
             call write_smapL4SMaup( 'analysis', date_time_new, trim(out_path),     &
             trim(exp_id), NUM_ENSEMBLE, N_catl, N_catf, N_obsl, tile_coord_rf,     &
-            tcinternal%grid_g, N_catl_vec, low_ind,                                &
+            tcinternal%pgrid_g, N_catl_vec, low_ind,                                &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn   )
 
     end if ! end if (.true.)

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1840,8 +1840,8 @@ contains
          NUM_ENSEMBLE, N_catl, N_catf, N_obsl_max,                         &
          trim(out_path), trim(exp_id), exp_domain,                         &
          met_force, lai, cat_param, mwRTM_param,                           &
-         tile_coord_l, tile_coord_rf, tcinternal%pgrid_f,                   &
-         tcinternal%pgrid_f, tcinternal%pgrid_l, tcinternal%pgrid_g,          &
+         tile_coord_l, tile_coord_rf,                                      &
+         tcinternal%pgrid_f, tcinternal%pgrid_g,                           &
          N_catl_vec, low_ind, l2rf, rf2l,                                  &
          N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
          update_type,                                                      &

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1841,7 +1841,7 @@ contains
          trim(out_path), trim(exp_id), exp_domain,                         &
          met_force, lai, cat_param, mwRTM_param,                           &
          tile_coord_l, tile_coord_rf,                                      &
-         tcinternal%pgrid_f, tcinternal%pgrid_g, tcinternal%grid_g,        &
+         tcinternal%tgrid_g, tcinternal%pgrid_f, tcinternal%pgrid_g,       &
          N_catl_vec, low_ind, l2rf, rf2l,                                  &
          N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
          update_type,                                                      &
@@ -1957,7 +1957,7 @@ contains
        if (out_smapL4SMaup)                                                        &
             call write_smapL4SMaup( 'analysis', date_time_new, trim(out_path),     &
             trim(exp_id), NUM_ENSEMBLE, N_catl, N_catf, N_obsl, tile_coord_rf,     &
-            tcinternal%grid_g, N_catl_vec, low_ind,                                &
+            tcinternal%tgrid_g, N_catl_vec, low_ind,                                &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn   )
 
     end if ! end if (.true.)

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_adapt_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_adapt_routines.F90
@@ -943,10 +943,10 @@ contains
           
           ! get mean and std in tile space 
           
-          call grid2tile( pert_grid, N_catd, tile_coord%hash_i_indg,tile_coord%hash_j_indg, & !tile_coord,       &
+          call grid2tile( pert_grid, N_catd, tile_coord%pert_i_indg,tile_coord%pert_j_indg, & !tile_coord,       &
                pert_param(n)%mean, mu )
 
-          call grid2tile( pert_grid, N_catd, tile_coord%hash_i_indg,tile_coord%hash_j_indg, & !tile_coord,       &
+          call grid2tile( pert_grid, N_catd, tile_coord%pert_i_indg,tile_coord%pert_j_indg, & !tile_coord,       &
                pert_param(n)%std,  sg )
           
           select case (pert_param(n)%typ)

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -143,7 +143,7 @@ contains
        work_path, exp_id, exp_domain,                                    &
        met_force, lai, cat_param, mwRTM_param,                           &
        tile_coord_l, tile_coord_f,                                       &
-       pert_grid_f, pert_grid_g,                                         &
+       pert_grid_f, pert_grid_g, tile_grid_g,                            &
        N_catl_vec, low_ind, l2f, f2l,                                    &
        N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
        update_type,                                                      &
@@ -192,7 +192,7 @@ contains
 
     type(tile_coord_type), dimension(:), pointer :: tile_coord_l, tile_coord_f  ! input
 
-    type(grid_def_type), intent(in) :: pert_grid_f, pert_grid_g
+    type(grid_def_type), intent(in) :: pert_grid_f, pert_grid_g, tile_grid_g
 
     integer, intent(in), dimension(numprocs) :: N_catl_vec, low_ind
 
@@ -394,12 +394,12 @@ contains
 
           ! first call: count how many tiles are in each pert_grid_f cell
           call get_number_of_tiles_in_cell_ij( N_catf,                           &
-               tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
+               tile_coord_f%pert_i_indg, tile_coord_f%pert_j_indg,               &
                pert_grid_f, N_tile_in_cell_ij_f )
           ! second call: find out which tiles are in each pert_grid_f cell
 
           call get_tile_num_in_cell_ij( N_catf,                                  &
-               tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
+               tile_coord_f%pert_i_indg, tile_coord_f%pert_j_indg,               &
                pert_grid_f, maxval(N_tile_in_cell_ij_f), tile_num_in_cell_ij_f )
        else
           allocate(N_tile_in_cell_ij_f(0,0)) !for debugging
@@ -418,7 +418,7 @@ contains
        if (out_smapL4SMaup)                                                        &
             call output_smapL4SMaup( date_time, work_path, exp_id, dtstep_assim,   &
             N_ens, N_catl, N_catf, N_obsl, N_obsl_max,                             &
-            tile_coord_f, tile_coord_l, pert_grid_g, pert_grid_f,                  &
+            tile_coord_f, tile_coord_l, tile_grid_g, pert_grid_f,                  &
             N_catl_vec, low_ind, l2f, N_tile_in_cell_ij_f, tile_num_in_cell_ij_f,  &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn  )
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -142,8 +142,8 @@ contains
        N_ens, N_catl, N_catf, N_obsl_max,                                &
        work_path, exp_id, exp_domain,                                    &
        met_force, lai, cat_param, mwRTM_param,                           &
-       tile_coord_l, tile_coord_f, pert_grid_f_NotUsed,                  &
-       pert_grid_f, pert_grid_l_NotUsed, pert_grid_g,                    &
+       tile_coord_l, tile_coord_f,                                       &
+       pert_grid_f, pert_grid_g,                                         &
        N_catl_vec, low_ind, l2f, f2l,                                    &
        N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
        update_type,                                                      &
@@ -192,7 +192,7 @@ contains
 
     type(tile_coord_type), dimension(:), pointer :: tile_coord_l, tile_coord_f  ! input
 
-    type(grid_def_type), intent(in) :: pert_grid_f_NotUsed, pert_grid_f, pert_grid_l_NotUsed, pert_grid_g
+    type(grid_def_type), intent(in) :: pert_grid_f, pert_grid_g
 
     integer, intent(in), dimension(numprocs) :: N_catl_vec, low_ind
 
@@ -1046,7 +1046,7 @@ contains
           call cat_enkf_increments(                       &
                N_ens, nObs_ana, nTiles_ana, N_obs_param,  &
                update_type, obs_param,                    &
-               pert_grid_f, tile_coord_ana, indTiles_ana, & ! indTiles_ana is essentially ana2f
+               tile_coord_ana, indTiles_ana,              & ! indTiles_ana is essentially ana2f
                Obs_ana,                                   & ! size: nObs_ana
                Obs_pred_ana,                              & ! size: (nObs_ana,N_ens)
                Obs_pert_tmp,                              &
@@ -1074,7 +1074,7 @@ contains
           call cat_enkf_increments(                                     &
                N_ens, N_obslH, N_catl, N_obs_param,                     &
                update_type, obs_param,                                  &
-               pert_grid_f, tile_coord_l, l2f,                          &
+               tile_coord_l, l2f,                                       &
                Observations_lH(1:N_obslH),                              &
                Obs_pred_lH(1:N_obslH,1:N_ens),                          &
                Obs_pert_tmp,                                            &

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -143,7 +143,7 @@ contains
        work_path, exp_id, exp_domain,                                    &
        met_force, lai, cat_param, mwRTM_param,                           &
        tile_coord_l, tile_coord_f,                                       &
-       pert_grid_f, pert_grid_g, tile_grid_g,                            &
+       tile_grid_g, pert_grid_f, pert_grid_g,                            &
        N_catl_vec, low_ind, l2f, f2l,                                    &
        N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
        update_type,                                                      &
@@ -192,7 +192,7 @@ contains
 
     type(tile_coord_type), dimension(:), pointer :: tile_coord_l, tile_coord_f  ! input
 
-    type(grid_def_type), intent(in) :: pert_grid_f, pert_grid_g, tile_grid_g
+    type(grid_def_type), intent(in) :: tile_grid_g, pert_grid_f, pert_grid_g
 
     integer, intent(in), dimension(numprocs) :: N_catl_vec, low_ind
 
@@ -1196,7 +1196,7 @@ contains
 
        if (out_smapL4SMaup)                                                          &
             call write_smapL4SMaup( 'obs_fcst', date_time, work_path, exp_id, N_ens, &
-            N_catl, N_catf, N_obsl, tile_coord_f, pert_grid_g, N_catl_vec, low_ind,  &
+            N_catl, N_catf, N_obsl, tile_coord_f, tile_grid_g, N_catl_vec, low_ind,  &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn       )
 
     end if  ! end if (.true.)

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -142,8 +142,8 @@ contains
        N_ens, N_catl, N_catf, N_obsl_max,                                &
        work_path, exp_id, exp_domain,                                    &
        met_force, lai, cat_param, mwRTM_param,                           &
-       tile_coord_l, tile_coord_f, tile_grid_f,                          &
-       pert_grid_f, pert_grid_l_NotUsed, tile_grid_g,                    &
+       tile_coord_l, tile_coord_f, pert_grid_f_NotUsed,                  &
+       pert_grid_f, pert_grid_l_NotUsed, pert_grid_g,                    &
        N_catl_vec, low_ind, l2f, f2l,                                    &
        N_force_pert, N_progn_pert, force_pert_param, progn_pert_param,   &
        update_type,                                                      &
@@ -192,7 +192,7 @@ contains
 
     type(tile_coord_type), dimension(:), pointer :: tile_coord_l, tile_coord_f  ! input
 
-    type(grid_def_type), intent(in) :: tile_grid_f, pert_grid_f, pert_grid_l_NotUsed, tile_grid_g
+    type(grid_def_type), intent(in) :: pert_grid_f_NotUsed, pert_grid_f, pert_grid_l_NotUsed, pert_grid_g
 
     integer, intent(in), dimension(numprocs) :: N_catl_vec, low_ind
 
@@ -390,17 +390,17 @@ contains
        if ( (root_proc)                                        .or.              &
             (any(obs_param(1:N_obs_param)%FOV>FOV_threshold))        )  then
 
-          allocate(N_tile_in_cell_ij_f(tile_grid_f%N_lon,tile_grid_f%N_lat))
+          allocate(N_tile_in_cell_ij_f(pert_grid_f%N_lon,pert_grid_f%N_lat))
 
-          ! first call: count how many tiles are in each tile_grid_f cell
+          ! first call: count how many tiles are in each pert_grid_f cell
           call get_number_of_tiles_in_cell_ij( N_catf,                           &
                tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
-               tile_grid_f, N_tile_in_cell_ij_f )
-          ! second call: find out which tiles are in each tile_grid_f cell
+               pert_grid_f, N_tile_in_cell_ij_f )
+          ! second call: find out which tiles are in each pert_grid_f cell
 
           call get_tile_num_in_cell_ij( N_catf,                                  &
                tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg,               &
-               tile_grid_f, maxval(N_tile_in_cell_ij_f), tile_num_in_cell_ij_f )
+               pert_grid_f, maxval(N_tile_in_cell_ij_f), tile_num_in_cell_ij_f )
        else
           allocate(N_tile_in_cell_ij_f(0,0)) !for debugging
        end if
@@ -418,7 +418,7 @@ contains
        if (out_smapL4SMaup)                                                        &
             call output_smapL4SMaup( date_time, work_path, exp_id, dtstep_assim,   &
             N_ens, N_catl, N_catf, N_obsl, N_obsl_max,                             &
-            tile_coord_f, tile_coord_l, tile_grid_g, tile_grid_f,                  &
+            tile_coord_f, tile_coord_l, pert_grid_g, pert_grid_f,                  &
             N_catl_vec, low_ind, l2f, N_tile_in_cell_ij_f, tile_num_in_cell_ij_f,  &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn  )
 
@@ -427,7 +427,7 @@ contains
        call collect_obs(                                              &
             work_path, exp_id, date_time, dtstep_assim,               &
             N_catl, tile_coord_l,                                     &
-            N_catf, tile_coord_f, tile_grid_f,                        &
+            N_catf, tile_coord_f, pert_grid_f,                        &
             N_tile_in_cell_ij_f, tile_num_in_cell_ij_f,               &
             N_catl_vec, low_ind, l2f,                                 &
             N_obs_param, obs_param, N_obsl_max, out_obslog,           &
@@ -510,7 +510,7 @@ contains
                N_obs_param, N_ens,                                &
                N_catl, tile_coord_l,                              &
                N_catf, tile_coord_f, f2l,                         &
-               N_catl_vec, low_ind, tile_grid_g,                  &
+               N_catl_vec, low_ind, pert_grid_g,                  &
                obs_param,                                         &
                met_force, lai, cat_param, cat_progn, mwRTM_param, &
                N_obsl, Observations_l, Obs_pred_l, obsbias_ok,    &
@@ -1046,7 +1046,7 @@ contains
           call cat_enkf_increments(                       &
                N_ens, nObs_ana, nTiles_ana, N_obs_param,  &
                update_type, obs_param,                    &
-               tile_grid_f, tile_coord_ana, indTiles_ana, & ! indTiles_ana is essentially ana2f
+               pert_grid_f, tile_coord_ana, indTiles_ana, & ! indTiles_ana is essentially ana2f
                Obs_ana,                                   & ! size: nObs_ana
                Obs_pred_ana,                              & ! size: (nObs_ana,N_ens)
                Obs_pert_tmp,                              &
@@ -1074,7 +1074,7 @@ contains
           call cat_enkf_increments(                                     &
                N_ens, N_obslH, N_catl, N_obs_param,                     &
                update_type, obs_param,                                  &
-               tile_grid_f, tile_coord_l, l2f,                          &
+               pert_grid_f, tile_coord_l, l2f,                          &
                Observations_lH(1:N_obslH),                              &
                Obs_pred_lH(1:N_obslH,1:N_ens),                          &
                Obs_pert_tmp,                                            &
@@ -1196,7 +1196,7 @@ contains
 
        if (out_smapL4SMaup)                                                          &
             call write_smapL4SMaup( 'obs_fcst', date_time, work_path, exp_id, N_ens, &
-            N_catl, N_catf, N_obsl, tile_coord_f, tile_grid_g, N_catl_vec, low_ind,  &
+            N_catl, N_catf, N_obsl, tile_coord_f, pert_grid_g, N_catl_vec, low_ind,  &
             N_obs_param, obs_param, Observations_l, cat_param, cat_progn       )
 
     end if  ! end if (.true.)
@@ -1626,7 +1626,7 @@ contains
        date_time, work_path, exp_id,                                         &
        N_obsl, N_obs_param, N_ens,                                           &
        N_catl, tile_coord_l,                                                 &
-       N_catf, tile_coord_f, tile_grid_f, tile_grid_g,                       &
+       N_catf, tile_coord_f, pert_grid_f, pert_grid_g,                       &
        N_catl_vec, low_ind, f2l, N_catg, f2g,                                &
        obs_param,                                                            &
        met_force, lai, cat_param, cat_progn, cat_progn_incr, mwRTM_param,    &
@@ -1654,8 +1654,8 @@ contains
     type(tile_coord_type),  dimension(:),     pointer :: tile_coord_l  ! input
     type(tile_coord_type),  dimension(:),     pointer :: tile_coord_f  ! input
 
-    type(grid_def_type),                              intent(in) :: tile_grid_f
-    type(grid_def_type),                              intent(in) :: tile_grid_g
+    type(grid_def_type),                              intent(in) :: pert_grid_f
+    type(grid_def_type),                              intent(in) :: pert_grid_g
 
     integer,                dimension(numprocs),      intent(in) :: N_catl_vec, low_ind
 
@@ -1716,7 +1716,7 @@ contains
             N_obs_param, N_ens,                                &
             N_catl, tile_coord_l,                              &
             N_catf, tile_coord_f, f2l,                         &
-            N_catl_vec, low_ind, tile_grid_g,                  &
+            N_catl_vec, low_ind, pert_grid_g,                  &
             obs_param,                                         &
             met_force, lai, cat_param, cat_progn, mwRTM_param, &
             N_obsl_tmp, Observations_l, Obs_pred_l )
@@ -1831,7 +1831,7 @@ contains
 
   subroutine output_smapL4SMaup( date_time, work_path, exp_id, dtstep_assim,    &
        N_ens, N_catl, N_catf, N_obsl, N_obsl_max,                               &
-       tile_coord_f, tile_coord_l, tile_grid_g, tile_grid_f,                    &
+       tile_coord_f, tile_coord_l, pert_grid_g, pert_grid_f,                    &
        N_catl_vec, low_ind, l2f, N_tile_in_cell_ij_f, tile_num_in_cell_ij_f,    &
        N_obs_param, obs_param, Observations_l, cat_param, cat_progn )
 
@@ -1860,8 +1860,8 @@ contains
     type(tile_coord_type), dimension(:),     pointer :: tile_coord_f  ! input
     type(tile_coord_type), dimension(:),     pointer :: tile_coord_l  ! input
 
-    type(grid_def_type),                             intent(in) :: tile_grid_g
-    type(grid_def_type),                             intent(in) :: tile_grid_f
+    type(grid_def_type),                             intent(in) :: pert_grid_g
+    type(grid_def_type),                             intent(in) :: pert_grid_f
 
     integer,               dimension(numprocs),      intent(in) :: N_catl_vec
     integer,               dimension(numprocs),      intent(in) :: low_ind
@@ -1936,7 +1936,7 @@ contains
     call collect_obs(                                                            &
          work_path, exp_id, date_time, dtstep_assim,                             &
          N_catl, tile_coord_l,                                                   &
-         N_catf, tile_coord_f, tile_grid_f,                                      &
+         N_catf, tile_coord_f, pert_grid_f,                                      &
          N_tile_in_cell_ij_f, tile_num_in_cell_ij_f,                             &
          N_catl_vec, low_ind, l2f,                                               &
          N_obs_param_tmp, obs_param_tmp(1:N_obs_param_tmp), N_obsl_max, .false., &
@@ -1945,7 +1945,7 @@ contains
     ! write appropriate fields (according to 'option') into file
 
     call write_smapL4SMaup( 'orig_obs', date_time, work_path, exp_id, N_ens,     &
-         N_catl, N_catf, N_obsl_tmp, tile_coord_f, tile_grid_g,                  &
+         N_catl, N_catf, N_obsl_tmp, tile_coord_f, pert_grid_g,                  &
          N_catl_vec, low_ind,                                                    &
          N_obs_param_tmp, obs_param_tmp(1:N_obs_param_tmp), Observations_l,      &
          cat_param, cat_progn       )
@@ -1955,7 +1955,7 @@ contains
   ! **********************************************************************
 
   subroutine write_smapL4SMaup( option, date_time, work_path, exp_id, N_ens,    &
-       N_catl, N_catf, N_obsl, tile_coord_f, tile_grid_g, N_catl_vec, low_ind,  &
+       N_catl, N_catf, N_obsl, tile_coord_f, pert_grid_g, N_catl_vec, low_ind,  &
        N_obs_param, obs_param, Observations_l, cat_param, cat_progn       )
 
     ! output of custom collection for SMAP L4_SM "aup" (analysis update)
@@ -2034,7 +2034,7 @@ contains
 
     type(tile_coord_type), dimension(:),     pointer :: tile_coord_f  ! input
 
-    type(grid_def_type),                             intent(in) :: tile_grid_g
+    type(grid_def_type),                             intent(in) :: pert_grid_g
 
     integer,               dimension(numprocs),      intent(in) :: N_catl_vec
     integer,               dimension(numprocs),      intent(in) :: low_ind
@@ -2105,7 +2105,7 @@ contains
     !
     ! smapL4SMaup output only works for 9 km EASE grids
 
-    if ( index(tile_grid_g%gridtype, 'M09') == 0  ) then
+    if ( index(pert_grid_g%gridtype, 'M09') == 0  ) then
        err_msg = 'out_smapL4SMaup requires tile-space for 9 km EASEv1 or EASEv2 grid'
        call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
     end if
@@ -2228,8 +2228,8 @@ contains
                   'SMAP_L1C_Tbh_E09_A', 'SMAP_L1C_Tbv_E09_A'    &
                   )
                
-                if (index(tile_grid_g%gridtype, 'M09') /=0) then 
-                   call  ease_convert(trim(tile_grid_g%gridtype), this_lat, this_lon, col_ind, row_ind)                
+                if (index(pert_grid_g%gridtype, 'M09') /=0) then 
+                   call  ease_convert(trim(pert_grid_g%gridtype), this_lat, this_lon, col_ind, row_ind)                
                 endif
 
                 ! col_ind and row_ind are zero-based, need one-based index here
@@ -2247,8 +2247,8 @@ contains
                   'SMAP_L1C_Tbh_E27_A', 'SMAP_L1C_Tbv_E27_A'    &
                   )
 
-                if (index(tile_grid_g%gridtype, 'M09') /=0) then
-                   call  ease_convert(trim(tile_grid_g%gridtype), this_lat, this_lon, col_ind, row_ind)             
+                if (index(pert_grid_g%gridtype, 'M09') /=0) then
+                   call  ease_convert(trim(pert_grid_g%gridtype), this_lat, this_lon, col_ind, row_ind)             
                 endif                
                 
                 ! col_ind and row_ind are zero-based, need one-based index here
@@ -2269,9 +2269,9 @@ contains
                   'SMOS_fit_Tbh_A', 'SMOS_fit_Tbv_A'    &
                   )
                 
-                if (index(tile_grid_g%gridtype, 'M09') /=0) then
+                if (index(pert_grid_g%gridtype, 'M09') /=0) then
                    ! subindex (1:7) to get the string EASEvx_
-                   gridname_tmp = tile_grid_g%gridtype(1:7)//'M36'
+                   gridname_tmp = pert_grid_g%gridtype(1:7)//'M36'
                    call  ease_convert(gridname_tmp, this_lat, this_lon, col_ind, row_ind)                
                 endif
 
@@ -2298,8 +2298,8 @@ contains
 
           ! map Observations%[xx] fields onto global 9km EASE grid,
 
-          allocate(ndata_h_9km_grid(tile_grid_g%N_lon,tile_grid_g%N_lat))
-          allocate(ndata_v_9km_grid(tile_grid_g%N_lon,tile_grid_g%N_lat))
+          allocate(ndata_h_9km_grid(pert_grid_g%N_lon,pert_grid_g%N_lat))
+          allocate(ndata_v_9km_grid(pert_grid_g%N_lon,pert_grid_g%N_lat))
 
           if (option=='orig_obs') then
 
@@ -2312,8 +2312,8 @@ contains
 
              allocate(Obs_f_tmpdata_8(N_obsf))
 
-             allocate(data_h_9km_grid_8(tile_grid_g%N_lon,tile_grid_g%N_lat))
-             allocate(data_v_9km_grid_8(tile_grid_g%N_lon,tile_grid_g%N_lat))
+             allocate(data_h_9km_grid_8(pert_grid_g%N_lon,pert_grid_g%N_lat))
+             allocate(data_v_9km_grid_8(pert_grid_g%N_lon,pert_grid_g%N_lat))
 
              allocate(data_h_9km_tile_8(N_catf))
              allocate(data_v_9km_tile_8(N_catf))
@@ -2326,8 +2326,8 @@ contains
 
              allocate(Obs_f_tmpdata(N_obsf))
 
-             allocate(data_h_9km_grid(tile_grid_g%N_lon,tile_grid_g%N_lat))
-             allocate(data_v_9km_grid(tile_grid_g%N_lon,tile_grid_g%N_lat))
+             allocate(data_h_9km_grid(pert_grid_g%N_lon,pert_grid_g%N_lat))
+             allocate(data_v_9km_grid(pert_grid_g%N_lon,pert_grid_g%N_lat))
 
              allocate(data_h_9km_tile(N_catf))
              allocate(data_v_9km_tile(N_catf))
@@ -2357,8 +2357,8 @@ contains
 
                    allocate(Obs_f_tmpdata(N_obsf))
 
-                   allocate(data_h_9km_grid(tile_grid_g%N_lon,tile_grid_g%N_lat))
-                   allocate(data_v_9km_grid(tile_grid_g%N_lon,tile_grid_g%N_lat))
+                   allocate(data_h_9km_grid(pert_grid_g%N_lon,pert_grid_g%N_lat))
+                   allocate(data_v_9km_grid(pert_grid_g%N_lon,pert_grid_g%N_lat))
 
                    allocate(data_h_9km_tile(N_catf))
                    allocate(data_v_9km_tile(N_catf))
@@ -2740,10 +2740,10 @@ contains
                 data_h_9km_tile_8 = real(nodata_generic,kind(0.0D0)) ! init (not in grid2tile!)
                 data_v_9km_tile_8 = real(nodata_generic,kind(0.0D0)) ! init (not in grid2tile!)
 
-                call grid2tile( tile_grid_g, N_catf, tile_coord_f%i_indg, tile_coord_f%j_indg, data_h_9km_grid_8, &
+                call grid2tile( pert_grid_g, N_catf, tile_coord_f%i_indg, tile_coord_f%j_indg, data_h_9km_grid_8, &
                      data_h_9km_tile_8 )
 
-                call grid2tile( tile_grid_g, N_catf, tile_coord_f%i_indg, tile_coord_f%j_indg, data_v_9km_grid_8, &
+                call grid2tile( pert_grid_g, N_catf, tile_coord_f%i_indg, tile_coord_f%j_indg, data_v_9km_grid_8, &
                      data_v_9km_tile_8 )
 
                 ! write into file
@@ -2756,10 +2756,10 @@ contains
                 data_h_9km_tile = nodata_generic  ! initialize (not done in grid2tile!)
                 data_v_9km_tile = nodata_generic  ! initialize (not done in grid2tile!)
 
-                call grid2tile( tile_grid_g, N_catf, tile_coord_f%i_indg,tile_coord_f%j_indg, data_h_9km_grid, &
+                call grid2tile( pert_grid_g, N_catf, tile_coord_f%i_indg,tile_coord_f%j_indg, data_h_9km_grid, &
                      data_h_9km_tile )
 
-                call grid2tile( tile_grid_g, N_catf, tile_coord_f%i_indg,tile_coord_f%j_indg, data_v_9km_grid, &
+                call grid2tile( pert_grid_g, N_catf, tile_coord_f%i_indg,tile_coord_f%j_indg, data_v_9km_grid, &
                      data_v_9km_tile )
 
                 ! write into file

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -3375,7 +3375,7 @@ contains
   subroutine cat_enkf_increments(                               &
        N_ens, N_obs, N_catd, N_obs_param,                       &
        update_type, obs_param,                                  &
-       tile_grid_f, tile_coord, l2f,                            &
+       tile_coord, l2f,                                         &
        Observations, Obs_pred, Obs_pert,                        &
        cat_param,                                               &
        xcompact, ycompact, fcsterr_inflation_fac,               &
@@ -3414,8 +3414,6 @@ contains
     integer, intent(in) :: N_ens, N_obs, N_catd, N_obs_param, update_type
 
     type(obs_param_type), dimension(N_obs_param), intent(in) :: obs_param               
-
-    type(grid_def_type), intent(in) :: tile_grid_f
 
     type(tile_coord_type), dimension(:), pointer  :: tile_coord     ! input
 
@@ -4943,7 +4941,7 @@ contains
        ! In the obs readers, each obs is assigned to a single tile
        ! based on subroutine get_tile_num_from_latlon().  The assignment
        ! is such that the the obs lat/lon and the tile center-of-mass lat/lon
-       ! must always be within the same grid cell of the tile_grid.
+       ! must always be within the same grid cell of the tile_grid [or pert_grid??].
        ! Furthermore, the obs lat/lon 
        !  - must be within the min/max lat/lon boundaries of the tile
        !  OR

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -79,7 +79,7 @@ module clsm_ensupd_upd_routines
        get_tile_num_in_ellipse,                   &
        get_number_of_tiles_in_cell_ij,            &
        get_tile_num_in_cell_ij,                   &
-       get_minimum_grid,                             &
+       get_minExtent_grid,                        &
        get_ij_ind_from_latlon
 
   use land_pert_routines,               ONLY:     &
@@ -1513,7 +1513,7 @@ contains
        
        ! determine tile_grid_lH from tile_coord_lH
        
-       tile_grid_lH = get_minimum_grid( N_catlH, tile_coord_lH%hash_i_indg, tile_coord_lH%hash_j_indg,  &
+       tile_grid_lH = get_minExtent_grid( N_catlH, tile_coord_lH%hash_i_indg, tile_coord_lH%hash_j_indg,&
             tile_coord_lH%min_lon, tile_coord_lH%min_lat, tile_coord_lH%max_lon, tile_coord_lH%max_lat, &
             tile_grid_g) 
        

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -79,7 +79,7 @@ module clsm_ensupd_upd_routines
        get_tile_num_in_ellipse,                   &
        get_number_of_tiles_in_cell_ij,            &
        get_tile_num_in_cell_ij,                   &
-       get_tile_grid,                             &
+       get_minimum_grid,                             &
        get_ij_ind_from_latlon
 
   use land_pert_routines,               ONLY:     &
@@ -1513,9 +1513,9 @@ contains
        
        ! determine tile_grid_lH from tile_coord_lH
        
-       call get_tile_grid( N_catlH, tile_coord_lH%hash_i_indg, tile_coord_lH%hash_j_indg,               &
+       tile_grid_lH = get_minimum_grid( N_catlH, tile_coord_lH%hash_i_indg, tile_coord_lH%hash_j_indg,  &
             tile_coord_lH%min_lon, tile_coord_lH%min_lat, tile_coord_lH%max_lon, tile_coord_lH%max_lat, &
-            tile_grid_g, tile_grid_lH ) 
+            tile_grid_g) 
        
        allocate(N_tile_in_cell_ij_lH(tile_grid_lH%N_lon,tile_grid_lH%N_lat))
        

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -1513,7 +1513,7 @@ contains
        
        ! determine tile_grid_lH from tile_coord_lH
        
-       tile_grid_lH = get_minExtent_grid( N_catlH, tile_coord_lH%hash_i_indg, tile_coord_lH%hash_j_indg,&
+       tile_grid_lH = get_minExtent_grid( N_catlH, tile_coord_lH%pert_i_indg, tile_coord_lH%pert_j_indg,&
             tile_coord_lH%min_lon, tile_coord_lH%min_lat, tile_coord_lH%max_lon, tile_coord_lH%max_lat, &
             tile_grid_g) 
        
@@ -1522,7 +1522,7 @@ contains
        ! first call: count how many tiles are in each tile_grid_lH cell
 
        call get_number_of_tiles_in_cell_ij( N_catlH,                                   &
-            tile_coord_lH%hash_i_indg, tile_coord_lH%hash_j_indg,                      &
+            tile_coord_lH%pert_i_indg, tile_coord_lH%pert_j_indg,                      &
             tile_grid_lH, N_tile_in_cell_ij_lH )
        
        ! second call: find out which tiles are in each tile_grid_lH cell
@@ -1530,7 +1530,7 @@ contains
        !               to local halo ("lH") domain]
        
        call get_tile_num_in_cell_ij( N_catlH,                                          &
-            tile_coord_lH%hash_i_indg, tile_coord_lH%hash_j_indg,                      &
+            tile_coord_lH%pert_i_indg, tile_coord_lH%pert_j_indg,                      &
             tile_grid_lH, maxval(N_tile_in_cell_ij_lH), tile_num_in_cell_ij_lH )
        
     end if

--- a/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
@@ -850,6 +850,7 @@ contains
     type(LANDPERT_WRAP) :: wrap
  
     type(TILECOORD_WRAP) :: tcwrap
+    type(T_TILECOORD_STATE), pointer :: tcinternal
     type(tile_coord_type), pointer :: tile_coord(:)=>null()
 
     ! MAPL internal pointers
@@ -895,7 +896,8 @@ contains
    ! Get component's internal tile_coord variable
     call ESMF_UserCompGetInternalState(gc, 'TILE_COORD', tcwrap, status)
     VERIFY_(status)
-    tile_coord => tcwrap%ptr%tile_coord
+    tcinternal => tcwrap%ptr
+    tile_coord => tcinternal%tile_coord
 
     ! Are we perturbing variables?
     call MAPL_GetResource(MAPL, internal%PERTURBATIONS, 'PERTURBATIONS:', default=0, rc=status)
@@ -931,20 +933,16 @@ contains
     GEOSldas_FORCE_PERT_DTSTEP = internal%ForcePert%dtstep
     GEOSldas_PROGN_PERT_DTSTEP = internal%PrognPert%dtstep
 
-    call get_pert_grid(tcwrap%ptr%grid_g,internal%pgrid_g)
-    call get_pert_grid(tcwrap%ptr%grid_f,internal%pgrid_f)
-    call get_pert_grid(tcwrap%ptr%grid_l,internal%pgrid_l)
- 
-    n_lon = internal%pgrid_l%n_lon
-    n_lat = internal%pgrid_l%n_lat
+    n_lon = tcinternal%pgrid_l%n_lon
+    n_lat = tcinternal%pgrid_l%n_lat
 
     call MAPL_GetResource( MAPL, ens_id_width,"ENS_ID_WIDTH:", default=4, RC=STATUS)
     VERIFY_(status)
 
    ! Pointers to mapl internals
     if ( internal%isCubedSphere ) then
-       n_lon_g = internal%pgrid_g%n_lon
-       n_lat_g = internal%pgrid_g%n_lat
+       n_lon_g = tcinternal%pgrid_g%n_lon
+       n_lat_g = tcinternal%pgrid_g%n_lat
        allocate(internal%fpert_ntrmdt(n_lon_g, n_lat_g, N_FORCE_PERT_MAX), source=0.0)
        allocate(internal%ppert_ntrmdt(n_lon_g, n_lat_g, N_PROGN_PERT_MAX), source=0.0)
        allocate(internal%pert_rseed_r8(NRANDSEED), source=0.0d0)
@@ -994,10 +992,10 @@ contains
              VERIFY_(status)
           endif
        endif 
-       lon1 = internal%pgrid_l%i_offg + 1
-       lon2 = internal%pgrid_l%i_offg + n_lon
-       lat1 = internal%pgrid_l%j_offg + 1
-       lat2 = internal%pgrid_l%j_offg + n_lat
+       lon1 = tcinternal%pgrid_l%i_offg + 1
+       lon2 = tcinternal%pgrid_l%i_offg + n_lon
+       lat1 = tcinternal%pgrid_l%j_offg + 1
+       lat2 = tcinternal%pgrid_l%j_offg + n_lat
     else
        call MAPL_Get(MAPL, INTERNAL_ESMF_STATE=MINTERNAL, rc=status)
        VERIFY_(status)
@@ -1012,10 +1010,10 @@ contains
        VERIFY_(status)
        call ESMF_GRID_INTERIOR  (GRID, I1,IN,J1,JN)
 
-       lon1 = internal%pgrid_l%i_offg + 1 ! global index, starting from 1
+       lon1 = tcinternal%pgrid_l%i_offg + 1 ! global index, starting from 1
        lon1 = lon1 - i1 + 1               ! relative to local
        lon2 = lon1 + n_lon - 1
-       lat1 = internal%pgrid_l%j_offg + 1 ! global index, starting from 1
+       lat1 = tcinternal%pgrid_l%j_offg + 1 ! global index, starting from 1
        lat1 = lat1 - j1 +1                ! relative to local
        lat2 = lat1 + n_lat - 1
     endif
@@ -1051,7 +1049,7 @@ contains
     ! Get pert options from *default* namelist files
     ! WARNING: get_force/progn_pert_param() calls allocate memory
 
-    call get_force_pert_param(internal%pgrid_l, internal%ForcePert%npert, internal%ForcePert%param)
+    call get_force_pert_param(tcinternal%pgrid_l, internal%ForcePert%npert, internal%ForcePert%param)
     _ASSERT(internal%ForcePert%npert==size(internal%ForcePert%param), "ForcePert: param size does not match npert")
 
     internal%ForcePert%fft_npert = internal%ForcePert%npert
@@ -1066,7 +1064,7 @@ contains
        call MAPL_CommsBcast(vm, data=internal%ForcePert%param(n)%coarsen,  N=1, ROOT=0,rc=status)
     enddo
 
-    call get_progn_pert_param(internal%pgrid_l, internal%PrognPert%npert, internal%PrognPert%param)
+    call get_progn_pert_param(tcinternal%pgrid_l, internal%PrognPert%npert, internal%PrognPert%param)
     _ASSERT(internal%PrognPert%npert==size(internal%PrognPert%param), "PrognPert: param size does not match npert")
 
     internal%PrognPert%fft_npert = internal%PrognPert%npert
@@ -1141,7 +1139,7 @@ contains
        call propagate_pert(                                                     &
             internal%ForcePert%fft_npert,                                       &
             1,                                                                  &
-            internal%pgrid_l, internal%pgrid_f,                                 &
+            tcinternal%pgrid_l, tcinternal%pgrid_f,                                 &
             ! arbitrary dtstep
             -1.0,                                                               &
             pert_rseed,                                                         &
@@ -1156,7 +1154,7 @@ contains
        call propagate_pert(                                                     &
             internal%PrognPert%fft_npert,                                       &
             1,                                                                  &
-            internal%pgrid_l, internal%pgrid_f,                                 &
+            tcinternal%pgrid_l, tcinternal%pgrid_f,                                 &
             ! arbitrary dtstep
             -1.0,                                                               &
             pert_rseed,                                                         &
@@ -1172,7 +1170,7 @@ contains
     if(internal%ens_id == FIRST_ENS_ID ) fpert_enavg(:,:,:)=0. 
 
     do m = 1,internal%ForcePert%npert
-       call tile_mask_grid(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_ntrmdt(lon1:lon2,lat1:lat2,m))
+       call tile_mask_grid(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_ntrmdt(lon1:lon2,lat1:lat2,m))
        if(internal%ForcePert%param(m)%zeromean .and. internal%NUM_ENSEMBLE >2) then
           fpert_enavg(:,:,m)=fpert_enavg(:,:,m)+fpert_ntrmdt(lon1:lon2,lat1:lat2,m)
           if( internal%ens_id-FIRST_ENS_ID == internal%NUM_ENSEMBLE-1) then
@@ -1184,7 +1182,7 @@ contains
     if(internal%ens_id == FIRST_ENS_ID) ppert_enavg(:,:,:)=0. 
 
     do m = 1,internal%PrognPert%npert  
-       call tile_mask_grid(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_ntrmdt(lon1:lon2,lat1:lat2,m))
+       call tile_mask_grid(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_ntrmdt(lon1:lon2,lat1:lat2,m))
        if(internal%PrognPert%param(m)%zeromean .and. internal%NUM_ENSEMBLE >2) then
           ppert_enavg(:,:,m)=ppert_enavg(:,:,m)+ppert_ntrmdt(lon1:lon2,lat1:lat2,m)
           if( internal%ens_id - FIRST_ENS_ID == internal%NUM_ENSEMBLE-1) then
@@ -1311,6 +1309,7 @@ contains
     type(LANDPERT_WRAP) :: wrap
  
     type(TILECOORD_WRAP) :: tcwrap
+    type(T_TILECOORD_STATE), pointer :: tcinternal
     type(tile_coord_type), pointer :: tile_coord(:)=>null()
 
     ! MAPL internal pointers
@@ -1349,13 +1348,14 @@ contains
     call ESMF_UserCompGetInternalState(gc, 'Landpert_state', wrap, status)
     VERIFY_(status)
     internal => wrap%ptr
-    n_lon = internal%pgrid_l%n_lon
-    n_lat = internal%pgrid_l%n_lat
 
    ! Get component's internal tile_coord variable
     call ESMF_UserCompGetInternalState(gc, 'TILE_COORD', tcwrap, status)
     VERIFY_(status)
-    tile_coord => tcwrap%ptr%tile_coord
+    tcinternal => tcwrap%ptr
+    tile_coord => tcinternal%tile_coord
+    n_lon = tcinternal%pgrid_l%n_lon
+    n_lat = tcinternal%pgrid_l%n_lat
 
     if (internal%PERTURBATIONS == 0) then ! no perturbations
        call MAPL_TimerOff(MAPL, "phase2_Initialize")
@@ -1419,7 +1419,7 @@ contains
          internal%ForcePert%npert,                                              &
          internal%ForcePert%fft_npert,                                          &
          1,                                                                     &
-         internal%pgrid_l, internal%pgrid_f,                                    &
+         tcinternal%pgrid_l, tcinternal%pgrid_f,                                    &
          real(internal%ForcePert%dtstep),                                       &
          internal%ForcePert%param,                                              &
          pert_rseed,                                                            &
@@ -1432,9 +1432,9 @@ contains
          )
 
     do ipert=1,internal%ForcePert%npert
-       call grid2tile( internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
+       call grid2tile( tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
                 fpert_grid(:,:,ipert), internal%ForcePert%DataPrv(:,ipert))
-       call tile_mask_grid(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_ntrmdt(lon1:lon2,lat1:lat2,ipert))
+       call tile_mask_grid(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_ntrmdt(lon1:lon2,lat1:lat2,ipert))
     end do
     internal%ForcePert%DataNxt = internal%ForcePert%DataPrv
 
@@ -1451,7 +1451,7 @@ contains
          internal%PrognPert%npert,                                              &
          internal%PrognPert%fft_npert,                                          &
          1,                                                                     &
-         internal%pgrid_l, internal%pgrid_f,                                    &
+         tcinternal%pgrid_l, tcinternal%pgrid_f,                                    &
          real(internal%PrognPert%dtstep),                                       &
          internal%PrognPert%param,                                              &
          pert_rseed,                                                            &
@@ -1464,9 +1464,9 @@ contains
          )
 
     do ipert=1,internal%PrognPert%npert
-       call grid2tile( internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_grid(:,:,ipert), &
+       call grid2tile( tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_grid(:,:,ipert), &
                 internal%PrognPert%DataPrv(:,ipert))
-       call tile_mask_grid(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_ntrmdt(lon1:lon2,lat1:lat2,ipert))
+       call tile_mask_grid(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_ntrmdt(lon1:lon2,lat1:lat2,ipert))
     end do
     internal%PrognPert%DataNxt = internal%PrognPert%DataPrv
 
@@ -1528,6 +1528,7 @@ contains
     type(T_LANDPERT_STATE), pointer :: internal=>null()
     type(LANDPERT_WRAP) :: wrap
     type(TILECOORD_WRAP) :: tcwrap
+    type(T_TILECOORD_STATE), pointer :: tcinternal
     type(MAPL_LocStream) :: locstream
  
     ! MAPL internal pointers
@@ -1562,13 +1563,17 @@ contains
     VERIFY_(status)
     internal => wrap%ptr
 
-    n_lon=internal%pgrid_l%n_lon
-    n_lat=internal%pgrid_l%n_lat
-
     if (internal%PERTURBATIONS == 0) then ! no perturbations
        call MAPL_TimerOff(MAPL, "GenerateRaw")
        RETURN_(ESMF_SUCCESS)
     end if
+
+    call ESMF_UserCompGetInternalState(gc, 'TILE_COORD', tcwrap, status)
+    VERIFY_(status)
+    tcinternal => tcwrap%ptr
+
+    n_lon=tcinternal%pgrid_l%n_lon
+    n_lat=tcinternal%pgrid_l%n_lat
 
     ! Get locstream
     call MAPL_Get(MAPL, LocStream=locstream,rc=status)
@@ -1617,22 +1622,20 @@ contains
        VERIFY_(STATUS)
        call MAPL_TileMaskGet(tilegrid,  mask, rc=status)
        VERIFY_(STATUS)
-       call ESMF_UserCompGetInternalState(gc, 'TILE_COORD', tcwrap, status)
-       VERIFY_(status)
 
        nfpert = internal%ForcePert%npert
        nppert = internal%PrognPert%npert
-       tile_coord_f => tcwrap%ptr%tile_coord_f
+       tile_coord_f => tcinternal%tile_coord_f
        n_tile =  size(tile_coord_f,1)
        ! 1) grid2tile
        allocate(tile_data_f(land_nt_local,nfpert))
        allocate(tile_data_p(land_nt_local,nppert))
        do m = 1, nfpert
-         call grid2tile(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
+         call grid2tile(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
                 fpert_ntrmdt(lon1:lon2,lat1:lat2,m), tile_data_f(:,m)) 
        enddo
        do m = 1, nppert
-         call grid2tile(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
+         call grid2tile(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
                 ppert_ntrmdt(lon1:lon2,lat1:lat2,m), tile_data_p(:,m)) 
        enddo
        ! 2) gather tiledata
@@ -1659,10 +1662,10 @@ contains
        if (IamRoot) then
        ! 3) tile2grid. simple reverser of grid2tile without weighted averaging/no-data-handling
           do m = 1, nfpert
-             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, internal%pgrid_g, tile_data_f_all(:,m), internal%fpert_ntrmdt(:,:,m))
+             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, tcinternal%pgrid_g, tile_data_f_all(:,m), internal%fpert_ntrmdt(:,:,m))
           enddo
           do m = 1, nppert
-             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, internal%pgrid_g, tile_data_p_all(:,m), internal%ppert_ntrmdt(:,:,m))
+             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, tcinternal%pgrid_g, tile_data_p_all(:,m), internal%ppert_ntrmdt(:,:,m))
           enddo
        
        ! 4) writing
@@ -1684,7 +1687,7 @@ contains
        call propagate_pert(                                                   &
           internal%ForcePert%fft_npert,                                       &
           1,                                                                  &
-          internal%pgrid_l, internal%pgrid_f,                                 &
+          tcinternal%pgrid_l, tcinternal%pgrid_f,                                 &
           real(internal%ForcePert%dtstep),                                    &
           pert_rseed,                                                         &
           internal%ForcePert%param,                                           &
@@ -1695,7 +1698,7 @@ contains
        if(internal%ens_id == FIRST_ENS_ID ) fpert_enavg(:,:,:)=0.    
 
        do m = 1,internal%ForcePert%npert
-          call tile_mask_grid(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_ntrmdt(lon1:lon2,lat1:lat2,m))
+          call tile_mask_grid(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_ntrmdt(lon1:lon2,lat1:lat2,m))
           if(internal%ForcePert%param(m)%zeromean .and. internal%NUM_ENSEMBLE >2) then
              fpert_enavg(:,:,m)=fpert_enavg(:,:,m)+fpert_ntrmdt(lon1:lon2,lat1:lat2,m)
              if( internal%ens_id - FIRST_ENS_ID == internal%NUM_ENSEMBLE-1) then              
@@ -1712,7 +1715,7 @@ contains
         call propagate_pert(                                                  &
            internal%PrognPert%fft_npert,                                      &
            1,                                                                 &
-           internal%pgrid_l, internal%pgrid_f,                                &
+           tcinternal%pgrid_l, tcinternal%pgrid_f,                                &
            real(internal%PrognPert%dtstep),                                   &
            pert_rseed,                                                        &
            internal%PrognPert%param,                                          &
@@ -1723,7 +1726,7 @@ contains
        if(internal%ens_id == FIRST_ENS_ID) ppert_enavg(:,:,:)=0.       
 
        do m = 1,internal%PrognPert%npert
-          call tile_mask_grid(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_ntrmdt(lon1:lon2,lat1:lat2,m))
+          call tile_mask_grid(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_ntrmdt(lon1:lon2,lat1:lat2,m))
           if(internal%PrognPert%param(m)%zeromean .and. internal%NUM_ENSEMBLE >2) then
               ppert_enavg(:,:,m)=ppert_enavg(:,:,m)+ppert_ntrmdt(lon1:lon2,lat1:lat2,m)
               if( internal%ens_id - FIRST_ENS_ID == internal%NUM_ENSEMBLE -1) then                      
@@ -1831,6 +1834,7 @@ contains
     real, allocatable :: FORCEPERT(:,:)
     real, allocatable :: fpert_grid(:,:,:)
     type(TILECOORD_WRAP) :: tcwrap
+    type(T_TILECOORD_STATE), pointer :: tcinternal
     type(tile_coord_type), pointer :: tile_coord(:)=>null()
 
     integer :: n_lon,n_lat
@@ -1866,13 +1870,14 @@ contains
     call ESMF_UserCompGetInternalState(gc, 'Landpert_state', wrap, status)
     VERIFY_(status)
     internal => wrap%ptr
-    n_lon = internal%pgrid_l%n_lon
-    n_lat = internal%pgrid_l%n_lat
 
    ! Get component's internal tile_coord variable
     call ESMF_UserCompGetInternalState(gc, 'TILE_COORD', tcwrap, status)
     VERIFY_(status)
-    tile_coord => tcwrap%ptr%tile_coord
+    tcinternal => tcwrap%ptr
+    n_lon = tcinternal%pgrid_l%n_lon
+    n_lat = tcinternal%pgrid_l%n_lat
+    tile_coord => tcinternal%tile_coord
 
     ! Get locstream
     call MAPL_Get(MAPL, LocStream=locstream,rc=status)
@@ -1951,7 +1956,7 @@ contains
                internal%ForcePert%npert,                                           &
                internal%ForcePert%fft_npert,                                       &
                1,                                                                  &
-               internal%pgrid_l, internal%pgrid_f,                                 &
+               tcinternal%pgrid_l, tcinternal%pgrid_f,                                 &
                real(internal%ForcePert%dtstep),                                    &
                internal%ForcePert%param,                                           &
                pert_rseed,                                                         &
@@ -1968,9 +1973,9 @@ contains
           ! -convert-nxt-gridded-perturbations-to-tile-
           call MAPL_TimerOn(MAPL, '-LocStreamTransform')
           do ipert=1,internal%ForcePert%npert
-             call grid2tile( internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_grid(:,:,ipert), &
+             call grid2tile( tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_grid(:,:,ipert), &
                   internal%ForcePert%DataNxt(:,ipert))
-             call tile_mask_grid(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_ntrmdt(lon1:lon2,lat1:lat2,ipert))
+             call tile_mask_grid(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), fpert_ntrmdt(lon1:lon2,lat1:lat2,ipert))
           end do
        
           call MAPL_TimerOff(MAPL, '-LocStreamTransform')
@@ -2267,6 +2272,7 @@ contains
     real, allocatable :: PROGNPERT(:,:)
     real, allocatable :: ppert_grid(:,:,:)
     type(TILECOORD_WRAP) :: tcwrap
+    type(T_TILECOORD_STATE), pointer :: tcinternal
     type(tile_coord_type), pointer :: tile_coord(:)=>null()
 
     integer :: n_lon,n_lat
@@ -2307,13 +2313,14 @@ contains
     call MAPL_TimerOn(MAPL, "TOTAL")
     call MAPL_TimerOn(MAPL, "Run_ApplyPrognPert")
 
-    n_lon = internal%pgrid_l%n_lon
-    n_lat = internal%pgrid_l%n_lat
 
    ! Get component's internal tile_coord variable
     call ESMF_UserCompGetInternalState(gc, 'TILE_COORD', tcwrap, status)
     VERIFY_(status)
-    tile_coord => tcwrap%ptr%tile_coord
+    tcinternal => tcwrap%ptr
+    n_lon = tcinternal%pgrid_l%n_lon
+    n_lat = tcinternal%pgrid_l%n_lat
+    tile_coord => tcinternal%tile_coord
  
     ! Pointers to imports
     call MAPL_GetPointer(import, tcPert, 'TCPert', rc=status)
@@ -2430,7 +2437,7 @@ contains
             internal%PrognPert%npert,                                           &
             internal%PrognPert%fft_npert,                                       &
             1,                                                                  &
-            internal%pgrid_l, internal%pgrid_f,                                 &
+            tcinternal%pgrid_l, tcinternal%pgrid_f,                                 &
             real(internal%PrognPert%dtstep),                                    &
             internal%PrognPert%param,                                           &
             pert_rseed,                                                         &
@@ -2446,9 +2453,9 @@ contains
        ! -convert-nxt-gridded-perturbations-to-tile-
        call MAPL_TimerOn(MAPL, '-LocStreamTransform')
        do ipert=1,internal%PrognPert%npert
-          call grid2tile( internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_grid(:,:,ipert), &
+          call grid2tile( tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_grid(:,:,ipert), &
                 internal%PrognPert%DataNxt(:,ipert))
-          call tile_mask_grid(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_ntrmdt(lon1:lon2,lat1:lat2,ipert))
+          call tile_mask_grid(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), ppert_ntrmdt(lon1:lon2,lat1:lat2,ipert))
        end do
        call MAPL_TimerOff(MAPL, '-LocStreamTransform')
 
@@ -2660,6 +2667,7 @@ contains
     type(LANDPERT_WRAP) :: wrap
     type(MAPL_LocStream) :: locstream
     type(TILECOORD_WRAP) :: tcwrap
+    type(T_TILECOORD_STATE), pointer :: tcinternal
     integer :: m,n_lon,n_lat, land_nt_local, ens_id_width
 
     integer :: nfpert, nppert, n_tile
@@ -2685,6 +2693,9 @@ contains
     call ESMF_UserCompGetInternalState(gc, 'Landpert_state', wrap, status)
     VERIFY_(status)
     internal => wrap%ptr
+    call ESMF_UserCompGetInternalState(gc, 'TILE_COORD', tcwrap, status)
+    VERIFY_(status)
+    tcinternal => tcwrap%ptr
 
     if ( internal%isCubedSphere .and. internal%PERTURBATIONS /= 0) then
        call MAPL_Get(MAPL, LocStream=locstream,rc=status)
@@ -2695,22 +2706,19 @@ contains
        VERIFY_(STATUS)
        call MAPL_TileMaskGet(tilegrid,  mask, rc=status)
        VERIFY_(STATUS)
-       call ESMF_UserCompGetInternalState(gc, 'TILE_COORD', tcwrap, status)
-       VERIFY_(status)
-
        nfpert = internal%ForcePert%npert
        nppert = internal%PrognPert%npert
-       tile_coord_f => tcwrap%ptr%tile_coord_f
+       tile_coord_f => tcinternal%tile_coord_f
        n_tile =  size(tile_coord_f,1)
        ! 1) grid2tile
        allocate(tile_data_f(land_nt_local,nfpert))
        allocate(tile_data_p(land_nt_local,nppert))
        do m = 1, nfpert
-         call grid2tile(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
+         call grid2tile(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
                 internal%fpert_ntrmdt(lon1:lon2,lat1:lat2,m), tile_data_f(:,m)) 
        enddo
        do m = 1, nppert
-         call grid2tile(internal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
+         call grid2tile(tcinternal%pgrid_l, land_nt_local, internal%i_indgs(:),internal%j_indgs(:), &
                 internal%ppert_ntrmdt(lon1:lon2,lat1:lat2,m), tile_data_p(:,m)) 
        enddo
        ! 2) gather tiledata
@@ -2739,10 +2747,10 @@ contains
        ! 3) tile2grid 
             ! this step is simply a reverse of grid2tile without any weighted   
           do m = 1, nfpert
-             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, internal%pgrid_g, tile_data_f_all(:,m), internal%fpert_ntrmdt(:,:,m))
+             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, tcinternal%pgrid_g, tile_data_f_all(:,m), internal%fpert_ntrmdt(:,:,m))
           enddo
           do m = 1, nppert
-             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, internal%pgrid_g, tile_data_p_all(:,m), internal%ppert_ntrmdt(:,:,m))
+             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, tcinternal%pgrid_g, tile_data_p_all(:,m), internal%ppert_ntrmdt(:,:,m))
           enddo
 
         ! 4) writing

--- a/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
@@ -31,7 +31,6 @@ module GEOS_LandPertGridCompMod
   use LDAS_PertRoutinesMod, only: get_progn_pert_param
   use LDAS_PertRoutinesMod, only: read_ens_prop_inputs
   use LDAS_PertRoutinesMod, only: echo_pert_param
-  use LDAS_PertRoutinesMod, only: get_pert_grid
   use LDAS_PertRoutinesMod, only: interpolate_pert_to_timestep
   use LDAS_PertRoutinesMod, only: check_pert_dtstep
   use LDAS_PertRoutinesMod, only: GEOSldas_FORCE_PERT_DTSTEP

--- a/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
@@ -1042,8 +1042,8 @@ contains
     VERIFY_(status) 
     allocate(internal%j_indgs(land_nt_local),stat=status)
     VERIFY_(status)
-    internal%i_indgs(:)=tile_coord(:)%hash_i_indg
-    internal%j_indgs(:)=tile_coord(:)%hash_j_indg
+    internal%i_indgs(:)=tile_coord(:)%pert_i_indg
+    internal%j_indgs(:)=tile_coord(:)%pert_j_indg
 
     ! Get pert options from *default* namelist files
     ! WARNING: get_force/progn_pert_param() calls allocate memory
@@ -1661,10 +1661,10 @@ contains
        if (IamRoot) then
        ! 3) tile2grid. simple reverser of grid2tile without weighted averaging/no-data-handling
           do m = 1, nfpert
-             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, tcinternal%pgrid_g, tile_data_f_all(:,m), internal%fpert_ntrmdt(:,:,m))
+             call tile2grid_simple( N_tile, tile_coord_f%pert_i_indg, tile_coord_f%pert_j_indg, tcinternal%pgrid_g, tile_data_f_all(:,m), internal%fpert_ntrmdt(:,:,m))
           enddo
           do m = 1, nppert
-             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, tcinternal%pgrid_g, tile_data_p_all(:,m), internal%ppert_ntrmdt(:,:,m))
+             call tile2grid_simple( N_tile, tile_coord_f%pert_i_indg, tile_coord_f%pert_j_indg, tcinternal%pgrid_g, tile_data_p_all(:,m), internal%ppert_ntrmdt(:,:,m))
           enddo
        
        ! 4) writing
@@ -2746,10 +2746,10 @@ contains
        ! 3) tile2grid 
             ! this step is simply a reverse of grid2tile without any weighted   
           do m = 1, nfpert
-             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, tcinternal%pgrid_g, tile_data_f_all(:,m), internal%fpert_ntrmdt(:,:,m))
+             call tile2grid_simple( N_tile, tile_coord_f%pert_i_indg, tile_coord_f%pert_j_indg, tcinternal%pgrid_g, tile_data_f_all(:,m), internal%fpert_ntrmdt(:,:,m))
           enddo
           do m = 1, nppert
-             call tile2grid_simple( N_tile, tile_coord_f%hash_i_indg, tile_coord_f%hash_j_indg, tcinternal%pgrid_g, tile_data_p_all(:,m), internal%ppert_ntrmdt(:,:,m))
+             call tile2grid_simple( N_tile, tile_coord_f%pert_i_indg, tile_coord_f%pert_j_indg, tcinternal%pgrid_g, tile_data_p_all(:,m), internal%ppert_ntrmdt(:,:,m))
           enddo
 
         ! 4) writing

--- a/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/LDAS_PertRoutines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/LDAS_PertRoutines.F90
@@ -641,7 +641,7 @@ contains
     character(len=30) :: latlon_gridname
     character(len=6) ::  lattmp,lontmp
 
-    type(grid_def_type)  :: tile_grid_g,tile_grid_tmp
+    type(grid_def_type)  :: latlon_grid_tmp
 
     integer :: n_x,i_off,j_off,n_lon,n_lat
 
@@ -677,9 +677,9 @@ contains
        write(lontmp,'(I6.6)') n_lon
        latlon_gridname = "DE"//lontmp//"x"//"PE"//lattmp
 
-       call LDAS_create_grid_g(latlon_gridname,n_lon,n_lat,tile_grid_g,i_off,j_off)
+       call LDAS_create_grid_g(latlon_gridname,n_lon,n_lat, latlon_grid_tmp,i_off,j_off)
 
-       pert_grid = tile_grid_g              
+       pert_grid = latlon_grid_tmp  
 
     endif
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/LDAS_PertRoutines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandpert_GridComp/LDAS_PertRoutines.F90
@@ -630,14 +630,14 @@ contains
   end subroutine check_pert_dtstep
 
   ! *********************************************************************
-  subroutine get_pert_grid( tile_grid, pert_grid )
+  function get_pert_grid( tile_grid) result (pert_grid)
 
     ! reichle, 20 May 2010
     ! jiang,   03/10/2017
     implicit none
 
     type(grid_def_type), intent(in)  :: tile_grid
-    type(grid_def_type), intent(out) :: pert_grid
+    type(grid_def_type)              :: pert_grid
     character(len=30) :: latlon_gridname
     character(len=6) ::  lattmp,lontmp
 
@@ -683,7 +683,7 @@ contains
 
     endif
 
-  end subroutine get_pert_grid
+  end function get_pert_grid
 
   ! *********************************************************************
 

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_PertTypes.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_PertTypes.F90
@@ -106,8 +106,7 @@ module LDAS_PertTypes
       integer :: ens_id
       integer :: NUM_ENSEMBLE
       logical :: isCubedSphere
-     ! pert grids - local and full
-      type(grid_def_type) :: pgrid_l, pgrid_f,pgrid_g
+
       integer,allocatable :: i_indgs(:)
       integer,allocatable :: j_indgs(:)
      ! if it is cubed-sphere grid, swith to internal start

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
@@ -471,13 +471,13 @@ contains
     !   then tc_[x]_indg must be tile_coord%[x]_indg
     !
     !   iff tile_grid_g is the grid that supports efficient mapping for perts and the EnKF analysis,
-    !   then tc_[x]_indg must be tile_coord%hash_[x]_indg
+    !   then tc_[x]_indg must be tile_coord%pert_[x]_indg
     !
     ! reichle, 20 June 2012 -- moved from within domain_setup() 
     !                           for re-use in get_obs_pred() 
     !
     ! reichle+wjiang, 19 Aug 2020 -- changed interface to generically accommodate use of
-    !                                tile_coord%[x]_indg or tile_coord%hash_[x]_indg
+    !                                tile_coord%[x]_indg or tile_coord%pert_[x]_indg
     !
     ! -------------------------------------------------------------------
     
@@ -623,12 +623,12 @@ contains
     !   then tc_[x]_indg must be tile_coord%[x]_indg
     !
     !   iff tile_grid_g is the grid that supports efficient mapping for perts and the EnKF analysis,
-    !   then tc_[x]_indg must be tile_coord%hash_[x]_indg
+    !   then tc_[x]_indg must be tile_coord%pert_[x]_indg
     !
     ! wjiang(?) -- split off from LDASsa legacy subroutine get_tile_num_in_cell_ij()
     !
     ! reichle+wjiang, 19 Aug 2020 -- changed interface to generically accommodate use of
-    !                                tile_coord%[x]_indg or tile_coord%hash_[x]_indg
+    !                                tile_coord%[x]_indg or tile_coord%pert_[x]_indg
     !
     ! ----------------------------------------------------------
     
@@ -694,12 +694,12 @@ contains
     !   then tc_[x]_indg must be tile_coord%[x]_indg
     !
     !   iff tile_grid_g is the grid that supports efficient mapping for perts and the EnKF analysis,
-    !   then tc_[x]_indg must be tile_coord%hash_[x]_indg
+    !   then tc_[x]_indg must be tile_coord%pert_[x]_indg
     !
     ! wjiang(?) -- split off from LDASsa legacy subroutine get_tile_num_in_cell_ij()
     !
     ! reichle+wjiang, 19 Aug 2020 -- changed interface to generically accommodate use of
-    !                                tile_coord%[x]_indg or tile_coord%hash_[x]_indg
+    !                                tile_coord%[x]_indg or tile_coord%pert_[x]_indg
     !
     ! ----------------------------------------------------------
     

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
@@ -42,7 +42,7 @@ module LDAS_TileCoordRoutines
 
   private
   
-  public :: get_minimum_grid
+  public :: get_minExtent_grid
   public :: get_number_of_tiles_in_cell_ij
   public :: get_tile_num_in_cell_ij
   public :: get_tile_num_in_ellipse
@@ -460,7 +460,7 @@ contains
   
   ! *******************************************************************
   
-  function get_minimum_grid( N_tile, tc_i_indg, tc_j_indg, tc_minlon, tc_minlat, tc_maxlon, tc_maxlat, &
+  function get_minExtent_grid( N_tile, tc_i_indg, tc_j_indg, tc_minlon, tc_minlat, tc_maxlon, tc_maxlat, &
        tile_grid_g) result( tile_grid )     
     
     ! get matching tile_grid for given tile_coord and (global) tile_grid_g
@@ -503,7 +503,7 @@ contains
     integer :: this_i_indg, this_j_indg
     integer , allocatable :: i_indg_(:), j_indg_(:)
     logical :: c3_grid 
-    character(len=*), parameter :: Iam = 'get_minimum_grid'
+    character(len=*), parameter :: Iam = 'get_minExtent_grid'
     character(len=400) :: err_msg
 
     ! -------------------------------------------------
@@ -607,7 +607,7 @@ contains
     tile_grid%i_dir    = tile_grid_g%i_dir
     tile_grid%j_dir    = tile_grid_g%j_dir
     
-  end function get_minimum_grid
+  end function get_minExtent_grid
 
   ! **********************************************************************
 

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
@@ -42,7 +42,7 @@ module LDAS_TileCoordRoutines
 
   private
   
-  public :: get_tile_grid
+  public :: get_minimum_grid
   public :: get_number_of_tiles_in_cell_ij
   public :: get_tile_num_in_cell_ij
   public :: get_tile_num_in_ellipse
@@ -460,8 +460,8 @@ contains
   
   ! *******************************************************************
   
-  subroutine get_tile_grid( N_tile, tc_i_indg, tc_j_indg, tc_minlon, tc_minlat, tc_maxlon, tc_maxlat, &
-       tile_grid_g, tile_grid )     
+  function get_minimum_grid( N_tile, tc_i_indg, tc_j_indg, tc_minlon, tc_minlat, tc_maxlon, tc_maxlat, &
+       tile_grid_g) result( tile_grid )     
     
     ! get matching tile_grid for given tile_coord and (global) tile_grid_g
     !
@@ -488,7 +488,7 @@ contains
     real,                  intent(in), dimension(N_tile) :: tc_maxlon, tc_maxlat
     
     type(grid_def_type),   intent(in)                    :: tile_grid_g
-    type(grid_def_type),   intent(out)                   :: tile_grid
+    type(grid_def_type)                                  :: tile_grid
     
     ! local variables
     
@@ -503,7 +503,7 @@ contains
     integer :: this_i_indg, this_j_indg
     integer , allocatable :: i_indg_(:), j_indg_(:)
     logical :: c3_grid 
-    character(len=*), parameter :: Iam = 'get_tile_grid'
+    character(len=*), parameter :: Iam = 'get_minimum_grid'
     character(len=400) :: err_msg
 
     ! -------------------------------------------------
@@ -607,7 +607,7 @@ contains
     tile_grid%i_dir    = tile_grid_g%i_dir
     tile_grid%j_dir    = tile_grid_g%j_dir
     
-  end subroutine get_tile_grid
+  end function get_minimum_grid
 
   ! **********************************************************************
 

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordRoutines.F90
@@ -463,15 +463,15 @@ contains
   function get_minExtent_grid( N_tile, tc_i_indg, tc_j_indg, tc_minlon, tc_minlat, tc_maxlon, tc_maxlat, &
        tile_grid_g) result( tile_grid )     
     
-    ! get matching tile_grid for given tile_coord and (global) tile_grid_g
+    ! get tile_grid with smallest extent for given set of tiles in tile_coord on (global) tile_grid_g
     !
     ! make sure to pass in consistent tile_coord (tc) and tile_grid_g inputs:
     !
     !   iff tile_grid_g is the grid that is associated with the tile space definition,
-    !   then tc_[x]_indg must be tile_coord%[x]_indg
+    !   then input tc_[x]_indg must be tile_coord%[x]_indg
     !
     !   iff tile_grid_g is the grid that supports efficient mapping for perts and the EnKF analysis,
-    !   then tc_[x]_indg must be tile_coord%pert_[x]_indg
+    !   then input tc_[x]_indg must be tile_coord%pert_[x]_indg
     !
     ! reichle, 20 June 2012 -- moved from within domain_setup() 
     !                           for re-use in get_obs_pred() 

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordType.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordType.F90
@@ -161,9 +161,9 @@ module LDAS_TileCoordType
      type(tile_coord_type), pointer, contiguous :: tile_coord(:)=>null()
      type(tile_coord_type), pointer, contiguous :: tile_coord_f(:)=>null()
      integer, pointer    :: l2f(:)=>null()
-     type(grid_def_type) :: grid_g
-     type(grid_def_type) :: grid_f
-     type(grid_def_type) :: grid_l
+     type(grid_def_type) :: pgrid_g
+     type(grid_def_type) :: pgrid_f
+     type(grid_def_type) :: pgrid_l
   end type T_TILECOORD_STATE
 
   type TILECOORD_WRAP

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordType.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordType.F90
@@ -214,7 +214,7 @@ contains
 
     type(grid_def_type), intent(in) :: grid_1, grid_2
     
-    if ( index(grid_1%gridtype,trim(grid_2%gridtype))>0        .and. &
+    if ( trim(grid_1%gridtype) == trim(grid_2%gridtype)        .and. &
          grid_1%ind_base == grid_2%ind_base                    .and. &
          grid_1%i_dir    == grid_2%i_dir                       .and. &
          grid_1%j_dir    == grid_2%j_dir                       .and. &

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordType.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordType.F90
@@ -161,10 +161,10 @@ module LDAS_TileCoordType
      type(tile_coord_type), pointer, contiguous :: tile_coord(:)=>null()
      type(tile_coord_type), pointer, contiguous :: tile_coord_f(:)=>null()
      integer, pointer    :: l2f(:)=>null()
-     type(grid_def_type) :: pgrid_g
-     type(grid_def_type) :: grid_g
-     type(grid_def_type) :: pgrid_f
-     type(grid_def_type) :: pgrid_l
+     type(grid_def_type) :: tgrid_g         ! tile_grid_g
+     type(grid_def_type) :: pgrid_g         ! pert_grid_g
+     type(grid_def_type) :: pgrid_f         ! pert_grid_f
+     type(grid_def_type) :: pgrid_l         ! pert_grid_l
   end type T_TILECOORD_STATE
 
   type TILECOORD_WRAP

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordType.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_TileCoordType.F90
@@ -59,11 +59,11 @@ module LDAS_TileCoordType
      real    :: max_lat      ! maximum latitude (bounding box for tile)
      integer :: i_indg       ! i index (w.r.t. *global* grid that cuts tiles) 
      integer :: j_indg       ! j index (w.r.t. *global* grid that cuts tiles)
-     ! For cubed-sphere tile spaces, hash_[x]_indg refers to a lat-lon "hash" grid that will 
+     ! For cubed-sphere tile spaces, pert_[x]_indg refers to a lat-lon perturbation grid that will 
      !   be created at runtime to support efficient mapping for perturbations and the EnKF analysis.
-     ! For EASE and LatLon tile spaces, hash_[x]_indg is identical to [x]_indg
-     integer :: hash_i_indg  ! i index (w.r.t. *global* "hash" grid for perts and EnKF) 
-     integer :: hash_j_indg  ! j index (w.r.t. *global* "hash" grid for perts and EnKF)
+     ! For EASE and LatLon tile spaces, pert_[x]_indg is identical to [x]_indg
+     integer :: pert_i_indg  ! i index (w.r.t. *global* pert_grid for perts and EnKF) 
+     integer :: pert_j_indg  ! j index (w.r.t. *global* pert_grid for perts and EnKF)
      real    :: frac_cell    ! area fraction of grid cell covered by tile
      real    :: frac_pfaf    ! fraction of Pfafstetter catchment for land tiles 
      real    :: area         ! area [km^2]
@@ -162,6 +162,7 @@ module LDAS_TileCoordType
      type(tile_coord_type), pointer, contiguous :: tile_coord_f(:)=>null()
      integer, pointer    :: l2f(:)=>null()
      type(grid_def_type) :: pgrid_g
+     type(grid_def_type) :: grid_g
      type(grid_def_type) :: pgrid_f
      type(grid_def_type) :: pgrid_l
   end type T_TILECOORD_STATE
@@ -367,8 +368,8 @@ contains
     ! reichle, 24 July 2010
     ! reichle,  2 May  2013 - changed N_tile to intent(in)
     ! reichle,  7 Jan  2014 - changed to binary (unformatted) I/O
-    ! wjiang, reichle, 18 Aug 2020 - Added initialization of %hash_[x]_indg during read.
-    !                                Note that %hash_[x]_indg is NOT written out.
+    ! wjiang, reichle, 18 Aug 2020 - Added initialization of %pert_[x]_indg during read.
+    !                                Note that %pert_[x]_indg is NOT written out.
 
     implicit none
     
@@ -465,9 +466,9 @@ contains
        read (unitnum, iostat=istat) tmp_real; if (istat>0) call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
        tile_coord(:)%elev= tmp_real(:)
 
-       ! Initialize [x]_indg to hash_[x]_indg.  For cs tile spaces, hash_[x]_indg will be redefined
-       tile_coord(:)%hash_i_indg = tile_coord(:)%i_indg
-       tile_coord(:)%hash_j_indg = tile_coord(:)%j_indg
+       ! Initialize [x]_indg to pert_[x]_indg.  For cs tile spaces, pert_[x]_indg will be redefined
+       tile_coord(:)%pert_i_indg = tile_coord(:)%i_indg
+       tile_coord(:)%pert_j_indg = tile_coord(:)%j_indg
        tile_coord(:)%f_num = -9999 ! not assigned values yet
        deallocate(tmp_int, tmp_real)
     case default

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_mpi.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_mpi.F90
@@ -138,11 +138,11 @@ contains
     !     real    :: max_lat      ! maximum latitude (bounding box for tile)
     !     integer :: i_indg       ! i index (w.r.t. *global* grid that cuts tiles) 
     !     integer :: j_indg       ! j index (w.r.t. *global* grid that cuts tiles)
-    !     ! For cubed-sphere tile spaces, hash_[x]_indg refers to a lat-lon "hash" grid that will 
+    !     ! For cubed-sphere tile spaces, pert_[x]_indg refers to a lat-lon "hash" grid that will 
     !     !   be created at runtime to support efficient mapping for perturbations and the EnKF analysis.
-    !     ! For EASE and LatLon tile spaces, hash_[x]_indg is identical to [x]_indg
-    !     integer :: hash_i_indg  ! i index (w.r.t. *global* "hash" grid for perts and EnKF) 
-    !     integer :: hash_j_indg  ! j index (w.r.t. *global* "hash" grid for perts and EnKF)
+    !     ! For EASE and LatLon tile spaces, pert_[x]_indg is identical to [x]_indg
+    !     integer :: pert_i_indg  ! i index (w.r.t. *global* "hash" grid for perts and EnKF) 
+    !     integer :: pert_j_indg  ! j index (w.r.t. *global* "hash" grid for perts and EnKF)
     !     real    :: frac_cell    ! area fraction of grid cell covered by tile
     !     real    :: frac_pfaf    ! fraction of Pfafstetter catchment for land tiles 
     !     real    :: area         ! area [km^2]
@@ -161,7 +161,7 @@ contains
     
     iblock(1) = 4
     iblock(2) = 6
-    iblock(3) = 4 ! i_indg, j_indg, hash_i_indg and hash_j_indg
+    iblock(3) = 4 ! i_indg, j_indg, pert_i_indg and pert_j_indg
     iblock(4) = 4
     
     idisp(1)  = 0

--- a/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_mpi.F90
+++ b/src/Components/GEOSldas_GridComp/Shared/LDAS_ensdrv_mpi.F90
@@ -138,11 +138,11 @@ contains
     !     real    :: max_lat      ! maximum latitude (bounding box for tile)
     !     integer :: i_indg       ! i index (w.r.t. *global* grid that cuts tiles) 
     !     integer :: j_indg       ! j index (w.r.t. *global* grid that cuts tiles)
-    !     ! For cubed-sphere tile spaces, pert_[x]_indg refers to a lat-lon "hash" grid that will 
+    !     ! For cubed-sphere tile spaces, pert_[x]_indg refers to a lat-lon perturbation grid that will 
     !     !   be created at runtime to support efficient mapping for perturbations and the EnKF analysis.
     !     ! For EASE and LatLon tile spaces, pert_[x]_indg is identical to [x]_indg
-    !     integer :: pert_i_indg  ! i index (w.r.t. *global* "hash" grid for perts and EnKF) 
-    !     integer :: pert_j_indg  ! j index (w.r.t. *global* "hash" grid for perts and EnKF)
+    !     integer :: pert_i_indg  ! i index (w.r.t. *global* pert_grid for perts and EnKF) 
+    !     integer :: pert_j_indg  ! j index (w.r.t. *global* pert_grid for perts and EnKF)
     !     real    :: frac_cell    ! area fraction of grid cell covered by tile
     !     real    :: frac_pfaf    ! fraction of Pfafstetter catchment for land tiles 
     !     real    :: area         ! area [km^2]


### PR DESCRIPTION
Use pert_grid as the standard names for perturbation and assimilation