### PR TITLE
Add Mironov soil dielectric mixing model and rough reflectivity parameter options

### DIFF
--- a/src/Applications/LDAS_App/LDASsa_DEFAULT_inputs_ensupd.nml
+++ b/src/Applications/LDAS_App/LDASsa_DEFAULT_inputs_ensupd.nml
@@ -103,9 +103,10 @@ fcsterr_inflation_fac = -9999.
 ! %RTM_ID         = ID of radiative transfer model to use for Tb forward modeling
 !                   (subroutine get_obs_pred()) 
 !                     0 = none
-!                     1 = tau-omega model as in De Lannoy et al. 2013 (doi:10.1175/JHM-D-12-092.1)
-!                     2 = same as 1 but without Pellarin atmospheric corrections
-!                     3 = ...
+!                     1 = L-band tau-omega model as in De Lannoy et al. 2013 (doi:10.1175/JHM-D-12-092.1) (SMOS)
+!                     2 = same as 1 but without Pellarin atm corr (SMAP)
+!                     3 = same as 1 but with Mironov and SMAP L2_SM pol mixing (SMOS)
+!                     4 = same as 3 but without Pellarin atm corr (targeted for SMAP L4_SM Version 8)
 ! %bias_Npar      = number of obs bias states tracked per day (integer)
 ! %bias_trel      = e-folding time scale of obs bias memory [s]
 ! %bias_tcut      = cutoff time for confident obs bias estimate [s]

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -17,6 +17,8 @@ module GEOS_LandAssimGridCompMod
   use ESMF_CFIOMOD,              only: ESMF_CFIOstrTemplate
   use GEOS_ExportCatchIncrGridCompMod, only: ExportCatchIncrSetServices=>SetServices  
   use MAPL_ConstantsMod,         only: MAPL_TICE
+
+  use LDAS_exceptionsMod,        only: ldas_abort, LDAS_GENERIC_ERROR
     
   use LDAS_TileCoordType,        only: tile_coord_type
   use LDAS_TileCoordType,        only: grid_def_type
@@ -67,7 +69,6 @@ module GEOS_LandAssimGridCompMod
   use mwRTM_routines,            only: mwRTM_get_Tb, catch2mwRTM_vars
 
   use, intrinsic :: ieee_arithmetic    
-
 
   implicit none
 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -2237,7 +2237,9 @@ contains
   ! ******************************************************************************
   
   ! subroutine to calculate Tb for HISTORY output
-  
+  !
+  ! IMPORTANT: hardwired mwRTM configuration for SMAP L-band Tb w/o Pellarin atm correction (RTM_ID=4)
+
   subroutine CALC_LAND_TB(gc, import, export, clock, rc)
     
     type(ESMF_GridComp), intent(inout) :: gc     ! Gridded component

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -2386,6 +2386,7 @@ contains
             SWE,                                  &   
             dummy_real,                           &   ! intent(in), "Tair", not used as long as "incl_atm_terms=.false." 
             incl_atm_terms,                       &   
+            'mironov',                       &
             Tb_h_tmp, Tb_v_tmp )                      ! intent(out) 'TB_LAND_1410MHZ_40DEG_HPOL',  'TB_LAND_1410MHZ_40DEG_VPOL'
        deallocate(dummy_real) 
     else

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -1350,57 +1350,26 @@ contains
           
           do j=1,N_TbuniqFreqAngRTMid
              
-             freq       = Tb_freq_ang_RTMid(j,1)
-             inc_angle  = Tb_freq_ang_RTMid(j,2)
-             RTM_id     = Tb_freq_ang_RTMid(j,3)
+             freq       =      Tb_freq_ang_RTMid(j,1)
+             inc_angle  =      Tb_freq_ang_RTMid(j,2)
+             RTM_id     = nint(Tb_freq_ang_RTMid(j,3))
 
              ! Select a specific configuration of the RTM via the field 
              ! "RTM_ID" in the "obs_param" type. 
              !
              ! %RTM_ID = ID of radiative transfer model to use for Tb forward modeling
              !           (subroutine get_obs_pred()) 
-             !           0 = none
-             !           1 = tau-omega model as in De Lannoy et al. 2013 (doi:10.1175/JHM-D-12-092.1)
-             !           2 = same as 1 but without Pellarin atmospheric corrections
-             !           3 = ...
+             !       0 = none
+             !       1 = L-band tau-omega model as in De Lannoy et al. 2013 (doi:10.1175/JHM-D-12-092.1) (SMOS)
+             !       2 = same as 1 but without Pellarin atm corr (SMAP)
+             !       3 = same as 1 but with Mironov and SMAP L2_SM pol mixing (SMOS)
+             !       4 = same as 3 but without Pellarin atm corr (targeted for SMAP L4_SM Version 8)
              
-             select case (RTM_id)
-                
-             case (1)
-                
-                ! bug fix: previously, mwRTM_get_Tb() was called without specifying the
-                !          sub-array of "stemp_l" that corresponds to ensemble member n_e
-                !          - reichle, 11 Dec 2013  
-                
-                call mwRTM_get_Tb(                                              &
-                     N_catl, freq, inc_angle, mwRTM_param, tile_coord_l%elev,   &
-                     lai, smoist, stemp_l(:,n_e), SWE, met_force%Tair, .true.,  &
-                     'wang',Tb_h_vec, Tb_v_vec )
-                
-             case (2)
-                
-                call mwRTM_get_Tb(                                              &
-                     N_catl, freq, inc_angle, mwRTM_param, tile_coord_l%elev,   &
-                     lai, smoist, stemp_l(:,n_e), SWE, met_force%Tair, .false., &
-                     'wang',Tb_h_vec, Tb_v_vec )
-
-             case (3)
-                
-                call mwRTM_get_Tb(                                              &
-                     N_catl, freq, inc_angle, mwRTM_param, tile_coord_l%elev,   &
-                     lai, smoist, stemp_l(:,n_e), SWE, met_force%Tair, .false., &
-                     'mironov',Tb_h_vec, Tb_v_vec )
-
-                
-             case default
-                
-                write (tmpstring10,*) RTM_ID
-                
-                err_msg = 'unknown or inconsistent RTM_ID=' // tmpstring10
-                call ldas_abort(LDAS_GENERIC_ERROR, Iam, err_msg)
-                
-             end select
-
+             call mwRTM_get_Tb(                                              &
+                  N_catl, freq, inc_angle, mwRTM_param, tile_coord_l%elev,   &
+                  lai, smoist, stemp_l(:,n_e), SWE, met_force%Tair, RTM_ID,  &
+                  Tb_h_vec, Tb_v_vec )
+             
              Tb_h_l(:,j,n_e) = Tb_h_vec
              Tb_v_l(:,j,n_e) = Tb_v_vec
              

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -1375,14 +1375,22 @@ contains
                 call mwRTM_get_Tb(                                              &
                      N_catl, freq, inc_angle, mwRTM_param, tile_coord_l%elev,   &
                      lai, smoist, stemp_l(:,n_e), SWE, met_force%Tair, .true.,  &
-                     Tb_h_vec, Tb_v_vec )
+                     'wang',Tb_h_vec, Tb_v_vec )
                 
              case (2)
                 
                 call mwRTM_get_Tb(                                              &
                      N_catl, freq, inc_angle, mwRTM_param, tile_coord_l%elev,   &
                      lai, smoist, stemp_l(:,n_e), SWE, met_force%Tair, .false., &
-                     Tb_h_vec, Tb_v_vec )
+                     'wang',Tb_h_vec, Tb_v_vec )
+
+             case (3)
+                
+                call mwRTM_get_Tb(                                              &
+                     N_catl, freq, inc_angle, mwRTM_param, tile_coord_l%elev,   &
+                     lai, smoist, stemp_l(:,n_e), SWE, met_force%Tair, .false., &
+                     'mironov',Tb_h_vec, Tb_v_vec )
+
                 
              case default
                 

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/mwRTM_routines.F90
@@ -952,8 +952,8 @@ contains
      REAL                 :: tmptaub, tmptaub2plus1, tmpdiffepsb
      REAL                 :: tmptauu, tmptauu2plus1, tmpdiffepsu
 
-     REAL                 :: tmpreal, tmpepsbreal2, tmpepbsimag2
-     REAL                 ::          tmpepsureal2, tmpepbuimag2
+     REAL                 :: tmpreal, tmpepsbreal2, tmpepsbimag2
+     REAL                 ::          tmpepsureal2, tmpepsuimag2
      
      ! --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
@gmao-rreichle Preliminary version with the updated mwRTM including mironov soil dielectric model and other parameters based on the SMAP Level 2 DCA algorithm. RTM_id is used but we need to think about how to get the value when land_assim is set to "false". 