### PR TITLE
Updates in prep for GEOSldas release v17.13.0: ESMA_env v4.9.1, ESMA_cmake v3.28.0, GMAO_Shared v1.9.0, GEOS_Util v2.0.0, MAPL v2.39.1, CHANGELOG.md

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -35,7 +35,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.39.1
+  tag: v2.35.2
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.15.0
+  tag: v4.9.1
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -41,6 +41,6 @@ MAPL:
 GEOSgcm_GridComp:
   local: ./src/Components/GEOSldas_GridComp/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v2.1.0
+  branch: develop
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse
   develop: develop

--- a/components.yaml
+++ b/components.yaml
@@ -35,7 +35,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.35.2
+  tag: v2.39.1
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.8.0
+  tag: v4.15.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.24.0
+  tag: v3.28.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -22,14 +22,14 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.7.0
+  tag: v1.9.0
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v1.0.1
+  tag: v1.1.1
   develop: main
 
 MAPL:
@@ -41,6 +41,6 @@ MAPL:
 GEOSgcm_GridComp:
   local: ./src/Components/GEOSldas_GridComp/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  branch: develop
+  tag: v2.1.0
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse
   develop: develop

--- a/components.yaml
+++ b/components.yaml
@@ -29,13 +29,13 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v1.1.1
+  tag: v2.0.0
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.35.2
+  tag: v2.39.1
   develop: develop
 
 GEOSgcm_GridComp:

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -33,7 +33,7 @@ This README file contains the history of stable GEOSldas versions ("tags") in Gi
 Overview of Git Releases:
 ============================
 
-[v17.13.0](https://github.com/GEOS-ESM/GEOSldas/releases/tag/v17.13.0) - 2023-05-12
+[v17.13.0](https://github.com/GEOS-ESM/GEOSldas/releases/tag/v17.13.0) - 2023-05-18
 ------------------------------
 
 - 0-diff vs. v17.12.0 except:
@@ -45,14 +45,19 @@ Overview of Git Releases:
   - Support for ensemble standard deviation output via HISTORY for selected variables ([PR #635](https://github.com/GEOS-ESM/GEOSldas/pull/635)).
 
 - GEOSgcm_GridComp:
-  - Updated to v2.1.0.
+  - Updated to v2.1.1.
+    - Restructured make bcs ([GEOSgcm_GridComp PR#718](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/718), [GEOSgcm_GridComp PR#729](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/729)).
+    - CatchmentCNCLM45 restart bug fixes (new optional restart variables) ([GEOSgcm_GridComp PR#657](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/657))
   - Cleaned up CatchCN restart routines ([PR #629](https://github.com/GEOS-ESM/GEOSldas/pull/629)). 
   - Updated paths to boundary conditions ([PR #634](https://github.com/GEOS-ESM/GEOSldas/pull/634)).
   - Adjusted to restructured `./Raster` (makebcs) libraries ([PR #615](https://github.com/GEOS-ESM/GEOSldas/pull/615)).
 
 - Utilities:
-  - Added GEOS_Util repo v1.1.1 ([PR #623](https://github.com/GEOS-ESM/GEOSldas/pull/623), [PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
+  - Updated ESMA_env to v4.9.1 ([PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
+  - Updated ESMA_cmake to v3.28.0 ([PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
   - Updated GMAO_Shared to v1.9.0 ([PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
+  - Added GEOS_Util repo v2.0.0 ([PR #623](https://github.com/GEOS-ESM/GEOSldas/pull/623), [PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
+  - Updated MAPL to v2.39.1 ([PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
   - Added matlab utilities for EASEv2 grid ([PR #622](https://github.com/GEOS-ESM/GEOSldas/pull/622), [PR #640](https://github.com/GEOS-ESM/GEOSldas/pull/640)).
 
 - Infrastructure:

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -51,8 +51,8 @@ Overview of Git Releases:
   - Adjusted to restructured `./Raster` (makebcs) libraries ([PR #615](https://github.com/GEOS-ESM/GEOSldas/pull/615)).
 
 - Utilities:
-  - Added GEOS_Util repo v1.1.1 ([PR #623, [PR #645](https://github.com/GEOS-ESM/GEOSldas/pull/645)).
-  - Updated GMAO_Shared to v1.9.0 ([PR #645](https://github.com/GEOS-ESM/GEOSldas/pull/645)).
+  - Added GEOS_Util repo v1.1.1 ([PR #623, [PR #645](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
+  - Updated GMAO_Shared to v1.9.0 ([PR #645](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
   - Added matlab utilities for EASEv2 grid ([PR #622, [PR #640](https://github.com/GEOS-ESM/GEOSldas/pull/640)).
 
 - Infrastructure:
@@ -61,7 +61,7 @@ Overview of Git Releases:
     - MAPL v2.35.2 ([PR #629](https://github.com/GEOS-ESM/GEOSldas/pull/629))
 
 - Documentation: 
-  - Improved documentation for input of heterogenous perturbations standard deviation from file (#628](https://github.com/GEOS-ESM/GEOSldas/pull/628)).
+  - Improved documentation for input of heterogenous perturbations standard deviation from file ([PR #628](https://github.com/GEOS-ESM/GEOSldas/pull/628)).
 
 - Bug fixes and other minor changes:
   - Fixed perturbations when root processor is not assigned any tiles ([PR #642](https://github.com/GEOS-ESM/GEOSldas/pull/642)).

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -46,11 +46,9 @@ Overview of Git Releases:
 
 - GEOSgcm_GridComp:
   - Updated to v2.1.1.
-    - Restructured make bcs ([GEOSgcm_GridComp PR#718](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/718), [GEOSgcm_GridComp PR#729](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/729)).
+    - Restructured `Raster/makebcs` and `mk_restarts` utilities: updated input paths, revised output directory tree ([PR #615](https://github.com/GEOS-ESM/GEOSldas/pull/615), [PR #634](https://github.com/GEOS-ESM/GEOSldas/pull/634), [GEOSgcm_GridComp PR#694](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/694), [GEOSgcm_GridComp PR#718](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/718), [GEOSgcm_GridComp PR#729](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/729)).
     - CatchmentCNCLM45 restart bug fixes (new optional restart variables) ([GEOSgcm_GridComp PR#657](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/657))
   - Cleaned up CatchCN restart routines ([PR #629](https://github.com/GEOS-ESM/GEOSldas/pull/629)). 
-  - Updated paths to boundary conditions ([PR #634](https://github.com/GEOS-ESM/GEOSldas/pull/634)).
-  - Adjusted to restructured `./Raster` (makebcs) libraries ([PR #615](https://github.com/GEOS-ESM/GEOSldas/pull/615)).
 
 - Utilities:
   - Updated ESMA_env to v4.9.1 ([PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -51,9 +51,9 @@ Overview of Git Releases:
   - Adjusted to restructured `./Raster` (makebcs) libraries ([PR #615](https://github.com/GEOS-ESM/GEOSldas/pull/615)).
 
 - Utilities:
-  - Added GEOS_Util repo v1.1.1 ([PR #623, [PR #645](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
-  - Updated GMAO_Shared to v1.9.0 ([PR #645](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
-  - Added matlab utilities for EASEv2 grid ([PR #622, [PR #640](https://github.com/GEOS-ESM/GEOSldas/pull/640)).
+  - Added GEOS_Util repo v1.1.1 ([PR #623](https://github.com/GEOS-ESM/GEOSldas/pull/623), [PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
+  - Updated GMAO_Shared to v1.9.0 ([PR #646](https://github.com/GEOS-ESM/GEOSldas/pull/646)).
+  - Added matlab utilities for EASEv2 grid ([PR #622](https://github.com/GEOS-ESM/GEOSldas/pull/622), [PR #640](https://github.com/GEOS-ESM/GEOSldas/pull/640)).
 
 - Infrastructure:
   - Updated CMake, MAPL: 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -33,6 +33,43 @@ This README file contains the history of stable GEOSldas versions ("tags") in Gi
 Overview of Git Releases:
 ============================
 
+[v17.13.0](https://github.com/GEOS-ESM/GEOSldas/releases/tag/v17.13.0) - 2023-05-12
+------------------------------
+
+- 0-diff vs. v17.12.0 except:
+  - Not 0-diff for diagnostic (HISTORY) output when bit shaving is applied ([PR #629](https://github.com/GEOS-ESM/GEOSldas/pull/629)). 
+  - Not 0-diff for simulations with CatchCN when using `RESTART: 2` ([PR #629](https://github.com/GEOS-ESM/GEOSldas/pull/629)).
+
+- Science changes:
+  - Added options to microwave radiative transfer model: Mironov soil dielectric mixing model, SMAP L2_SM_P rough reflectivity parameters ([PR #644](https://github.com/GEOS-ESM/GEOSldas/pull/644)).
+  - Support for ensemble standard deviation output via HISTORY for selected variables ([PR #635](https://github.com/GEOS-ESM/GEOSldas/pull/635)).
+
+- GEOSgcm_GridComp:
+  - Updated to v2.1.0.
+  - Cleaned up CatchCN restart routines ([PR #629](https://github.com/GEOS-ESM/GEOSldas/pull/629)). 
+  - Updated paths to boundary conditions ([PR #634](https://github.com/GEOS-ESM/GEOSldas/pull/634)).
+  - Adjusted to restructured `./Raster` (makebcs) libraries ([PR #615](https://github.com/GEOS-ESM/GEOSldas/pull/615)).
+
+- Utilities:
+  - Added GEOS_Util repo v1.1.1 ([PR #623, [PR #645](https://github.com/GEOS-ESM/GEOSldas/pull/645)).
+  - Updated GMAO_Shared to v1.9.0 ([PR #645](https://github.com/GEOS-ESM/GEOSldas/pull/645)).
+  - Added matlab utilities for EASEv2 grid ([PR #622, [PR #640](https://github.com/GEOS-ESM/GEOSldas/pull/640)).
+
+- Infrastructure:
+  - Updated CMake, MAPL: 
+    - ESMA_cmake v3.24.0 ([PR #618](https://github.com/GEOS-ESM/GEOSldas/pull/618))
+    - MAPL v2.35.2 ([PR #629](https://github.com/GEOS-ESM/GEOSldas/pull/629))
+
+- Documentation: 
+  - Improved documentation for input of heterogenous perturbations standard deviation from file (#628](https://github.com/GEOS-ESM/GEOSldas/pull/628)).
+
+- Bug fixes and other minor changes:
+  - Fixed perturbations when root processor is not assigned any tiles ([PR #642](https://github.com/GEOS-ESM/GEOSldas/pull/642)).
+  - Added custom messages to Github label enforcers ([PR #616](https://github.com/GEOS-ESM/GEOSldas/pull/616)).
+  - Set unlimited stack size in `ldas_setup` ([PR #620](https://github.com/GEOS-ESM/GEOSldas/pull/620)).
+  - Cleaned up variable name (`pert_grid`) in perturbation and assimilation subroutines ([PR #637](https://github.com/GEOS-ESM/GEOSldas/pull/637)).
+
+------------------------------
 [v17.12.0](https://github.com/GEOS-ESM/GEOSldas/releases/tag/v17.12.0) - 2022-12-16
 ------------------------------
 


### PR DESCRIPTION
PR updates ESMA_env (v4.9.1), ESMA_cmake (v3.28.0), GMAO_Shared (v1.9.0), GEOS_Util (v1.1.1), MAPL (v2.39.1), and CHANGELOG.md in preparation for GEOSldas release v17.13.0.

Note that MAPL v2.39.1 requires ESMA_cmake v3.28.0 in order to build.

Successful 0-diff test completed by @gmao-rreichle.  Non-0-diff changes seen in GCM with ESMA_cmake v3.28.0 are not seen in GEOSldas nightly tests. 
