### PR TITLE
update ESMA_env to v4.16.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.9.1
+  tag: v4.16.0
   develop: main
 
 cmake:


### PR DESCRIPTION
Update of ESMA_env to keep up with most recent version.

**Not 0-diff for cube-sphere** test cases because of precision changes in grid generation introduced with ESMA_env v4.10.0.

Tested by @gmao-rreichle on 19 May 2023:
- As expected, Intel/cube-sphere tests fail the comparison with trivial & acceptable roundoff differences (GLOBALCS, AGGGLOBALCS).  Roundoff differences are only in diagnostic HISTORY output.  Tile-based restart files are 0-diff. 
- All GNU tests passed (per @mathomp4, the test scripts still to point to the old g5_modules and Baselibs).

@mathomp4 might have another release of ESMA_cmake soon that is non-zero-diff for GNU.  We might want to bundle these additional non-zero-diff infrastructure updates into the present PR.  Keeping PR in "draft" mode for now. 

UPDATED by @gmao-rreichle 26 May 2023:   For reference, the GNU build change of https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/762 is limited to `moist` and does not impact `GEOSldas`.  This makes https://github.com/GEOS-ESM/ESMA_cmake/pull/318 obsolete and the present PR is ready for merging. 


cc: @biljanaorescanin @weiyuan-jiang 
