### PR TITLE
Hotfix: Change to GEOS_Util v2.0.1 (components.yaml)

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -25,7 +25,7 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.0.0
+  tag: v2.0.1
 
 MAPL:
   local: ./src/Shared/@MAPL


### PR DESCRIPTION
Updating to GEOS_Util v2.0.1 to fix a problem with remapping restarts in GEOSldas v17.13.0.
This is a hot fix directly on top of GEOSldas v17.13.0 to avoid the non-zero diff change associated with ESMA_env v4.16.0, which is already on the GEOSldas "develop" branch.
The bug fix in GEOS_Util is documented here: https://github.com/GEOS-ESM/GEOS_Util/pull/23 
@biljanaorescanin: Testing this PR is tricky because the current BASELINE in the nightly tests uses ESMA_env v4.16.0, which is not 0-diff against v17.13.0.  It should be possible to just run the nightly tests for this PR using the usual script, but then verify (manually) against the PREVIOUS test output (i.e., the older baseline).  If the latter is no longer available for some reason, we'd have to create output using v17.13.0.  The key is to make sure this PR is zero-diff against v17.13.0.  
