### PR TITLE
Move GEOSldas.F90 to use fArgParse

### DIFF
--- a/src/Applications/LDAS_App/GEOSldas.F90
+++ b/src/Applications/LDAS_App/GEOSldas.F90
@@ -4,7 +4,7 @@
 
 program LDAS_Main
 
-  
+
    ! !USES:
    use MAPL
    use GEOS_LDASGridCompMod, only:  ROOT_SetServices => SetServices
@@ -13,16 +13,15 @@ program LDAS_Main
 
    character(len=*), parameter :: Iam = "LDAS_Main"
    type (MAPL_Cap) :: cap
-   type (MAPL_FlapCLI) :: cli
+   type (MAPL_FargparseCLI) :: cli
    type (MAPL_CapOptions) :: cap_options
    integer :: status
 
 !EOP
 !----------------------------------------------------------------------
 !BOC
-  
-   cli = MAPL_FlapCLI(description = 'GEOS LDAS', &
-                      authors     = 'GMAO')
+
+   cli = MAPL_FargparseCLI()
    cap_options = MAPL_CapOptions(cli)
    cap_options%egress_file = 'EGRESS.ldas'
 
@@ -31,5 +30,5 @@ program LDAS_Main
 
    !call MAPL_CAP(ROOT_SetServices, FinalFile='EGRESS.ldas', rc=status)
    !VERIFY_(status)
-  
+
 end program LDAS_Main


### PR DESCRIPTION
This PR moves GEOSldas.F90 to use fArgParse instead of FLAP. In MAPL 3, FLAP support will be removed, but we can transition to fArgParse now that we use Baselibs 7.13.0. 

This is similar to PRs made for other executables (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/441)

This should work, though I'm sure @biljanaorescanin will test. But this isn't a critical fix, but we might as well transition from FLAP sooner rather than later.

Note: fArgParse doesn't (yet?) support the description and author fields when making the CLI.