### PR TITLE
add checks on snow states after application of LDAS increments

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -43,3 +43,4 @@ GEOSgcm_GridComp:
   remote: ../GEOSgcm_GridComp.git
   branch: feature/rreichle/snow_check_after_apply_LDAS_incr
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse
+  develop: develop

--- a/components.yaml
+++ b/components.yaml
@@ -41,6 +41,5 @@ MAPL:
 GEOSgcm_GridComp:
   local: ./src/Components/GEOSldas_GridComp/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  branch: develop
+  branch: feature/rreichle/snow_check_after_apply_LDAS_incr
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse
-  develop: develop

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensdrv_drv_routines.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensdrv_drv_routines.F90
@@ -68,12 +68,14 @@ contains
   
   ! ********************************************************************
     
-  subroutine check_cat_progn( N_cat, cat_param, cat_progn )
+  subroutine check_cat_progn( check_snow, N_cat, cat_param, cat_progn )
     
     ! wrapper for subroutine check_catch_progn() which has been 
     ! moved to "catch_iau.F90" in GEOScatch_GridComp - reichle, 3 Apr 2012
     
     implicit none
+    
+    logical, intent(in) :: check_snow
     
     integer, intent(in) :: N_cat
     
@@ -124,7 +126,8 @@ contains
          cat_progn%qa1,     cat_progn%qa2,    cat_progn%qa4,                      &
          cat_progn%capac,   cat_progn%catdef,                                     &
          cat_progn%rzexc,   cat_progn%srfexc,                                     &
-         ghtcnt, wesn, htsn, sndz            )
+         ghtcnt, wesn, htsn, sndz,                                                &
+         check_snow=check_snow)
     
     ! copy 2-d arrays back into cat_progn fields
     

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -1268,7 +1268,7 @@ contains
 
     integer :: n, n_e
 
-    logical :: cat_progn_has_changed
+    logical :: cat_progn_has_changed, check_snow
 
     character(len=*), parameter :: Iam = 'apply_enkf_increments'
     character(len=400) :: err_msg
@@ -1278,17 +1278,19 @@ contains
     ! apply increments
 
     cat_progn_has_changed = .true.     ! conservative initialization
-
+    
+    check_snow            = .true.     ! conservative initialization
+    
     select_update_type: select case (update_type)
-
+       
     case (1,2) select_update_type  ! soil moisture update
-
+       
        if (logit) write (logunit,*) &
             'apply_enkf_increments(): applying soil moisture increments'
-
+       
        do n=1,N_catd
           do n_e=1,N_ens
-
+             
              cat_progn(n,n_e)%srfexc = &
                   cat_progn(n,n_e)%srfexc + cat_progn_incr(n,n_e)%srfexc
              cat_progn(n,n_e)%rzexc = &
@@ -1369,6 +1371,8 @@ contains
 
        cat_progn_has_changed = .true.
 
+       check_snow            = .false.  ! turn off for now to maintain 0-diff w/ SMAP Tb DA test case
+
     case default
 
        call ldas_abort(LDAS_GENERIC_ERROR, Iam, 'unknown update_type')
@@ -1383,7 +1387,7 @@ contains
 
        do n_e=1,N_ens
 
-          call check_cat_progn( N_catd, cat_param, cat_progn(:,n_e) )
+          call check_cat_progn( check_snow, N_catd, cat_param, cat_progn(:,n_e) )
 
        end do
 


### PR DESCRIPTION
PR restores 0-diff of LDAS assim tests after merger of eponymous https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/834.

0-diff is maintained by turning off the new snow checks in the 3d Tb analysis for now.

Successfully tested for Intel by @gmao-rreichle.  Aggressive and GNU builds not yet tested.  May not be 0-diff or aggressive build (which would be acceptable).  Must be 0-diff for GNU.
