### PR TITLE
Remove requirement for mwRTM parameter files inputs

### DIFF
--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1886,19 +1886,29 @@ contains
          )
     _VERIFY(status)   
 
-    ! mwRTM_param already contains static parameters, only need vegopacity.
+    if ( mwRTM ) then
 
-    call get_vegopacity(MAPL, clock, N_catl, rc=status)
-    _VERIFY(STATUS)
+       ! mwRTM_param already contains static parameters, only need vegopacity.
 
-    ! Check no-data consistency of vegetation attenuation parameter values.
-    ! Good values are allowed for either the relevant static parameters
-    ! (bh, bv, lewt) or for the vegopacity values from the file, but not both.
-
-    do ii=1,N_catl
-       call mwRTM_param_nodata_check( mwRTM_param(ii) )
-    end do
+       call get_vegopacity(MAPL, clock, N_catl, rc=status)
+       _VERIFY(STATUS)
     
+       ! Check no-data consistency of vegetation attenuation parameter values.
+       ! Good values are allowed for either the relevant static parameters
+       ! (bh, bv, lewt) or for the vegopacity values from the file, but not both.
+
+       do ii=1,N_catl
+          call mwRTM_param_nodata_check( mwRTM_param(ii) )
+       end do
+
+    endif
+
+    if(.not. allocated(mwRTM_param)) then
+
+       allocate(mwRTM_param(1))
+
+     endif
+
     call get_enkf_increments(                                              &
          date_time_new,                                                    &
          NUM_ENSEMBLE, N_catl, N_catf, N_obsl_max,                         &

--- a/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -1905,7 +1905,7 @@ contains
 
     if(.not. allocated(mwRTM_param)) then
 
-       allocate(mwRTM_param(1))
+       allocate(mwRTM_param(0))
 
      endif
 


### PR DESCRIPTION
_Current behavior_
Currently the LDAS is assuming mwRTM parameter files inputs will be available and used, even if the mwRTM isn't being used in the analysis or for producing outputs (such as in an ASCAT SM only analysis). It exits trying to read a nonexistent vegopacity file, or passing an un-initialized `mwRTM_param` variable to `get_enkf_increments`. 

_Potential fix_
In GEOS_LandAssimGridComp.F90
1. `get_vegopcity` and `mwRTM_param_nodata_check` are only called if mwRTM is set to be true, which it will be if there mwRTM files in the nml.
2. If `mwRTM_param` isn't allocated during a mwRTM parameter file read, then `allocate(mwRTM_param(1))` just before call to `get_enkf_increments`

(It's unclear to me if allocating `mwRTM_param` like this but not  giving a value to it is good/acceptable practise)