### PR TITLE
Update CircleCI to use Orb v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,16 @@
 version: 2.1
 
-# Anchor to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.16.0
+# Anchors in case we need to override the defaults from the orb
+#baselibs_version: &baselibs_version v7.17.0
+#bcs_version: &bcs_version v11.4.0
 
 orbs:
-  ci: geos-esm/circleci-tools@1
+  ci: geos-esm/circleci-tools@2
 
 workflows:
   build-test:
     jobs:
+      # Build GEOSldas
       - ci/build:
           name: build-GEOSldas-on-<< matrix.compiler >>
           context:
@@ -16,7 +18,7 @@ workflows:
           matrix:
             parameters:
               compiler: [ifort, gfortran]
-          baselibs_version: *baselibs_version
+          #baselibs_version: *baselibs_version
           repo: GEOSldas
           mepodevelop: false
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra


### PR DESCRIPTION
This PR updates the CircleCI config the v2 orb. This has updates for Baselibs and fixes to other commands.