### PR TITLE
Update to ESMA_cmake v3.40.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.36.0
+  tag: v3.40.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
Our UFS colleagues have requested a change in how we link to ESMF in MAPL (see. For this, we need to update ESMA_cmake (see https://github.com/GEOS-ESM/MAPL/issues/2569). To do this, [ESMA_cmake v3.40.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.40.0) was released.

Because of this, MAPL 2.44 will require ESMA_cmake v3.40.0 and the [PR making the `ESMF::ESMF` change](https://github.com/GEOS-ESM/MAPL/pull/2575) is throwing a [CI fault](https://app.circleci.com/pipelines/github/GEOS-ESM/MAPL/7884/workflows/3e53f9c6-7075-4cd6-bb19-17ecdb79c344/jobs/57237) because GEOSldas doesn't yet have this. Thus this PR.

Note 1: this is an "if it builds, it works" since it only affects CMake, but of course @biljanaorescanin should test. I'll label as 0-diff instead of 0-diff trivial (though it's trivial to me :) )

Note 2: There is no requirement to update any CMake in LDAS for this. Our code now accepts `esmf`, `ESMF`, and `ESMF::ESMF` as targets. Eventually we will probably move all of GEOS code to the latter, but that will be later.

---

The changes from 3.36 to 3.40 are listed below. None of these affect compiler flags, etc. so it is zero-diff. They are mainly support for newer compilers, processors, etc for testing. The `ESMF::ESMF` is the big change.

## [3.40.0] - 2024-02-06

### Changed

- Updated `FindESMF.cmake` to the version from ESMF develop branch, commit da8f410. Will be in ESMF 8.6.1+
  - This provides the `ESMF::ESMF` alias for ESMF library for non-Baselibs builds

## [3.39.0] - 2024-02-06

### Added

- Added `ESMF::ESMF` alias for ESMF library
  - Needed to avoid an issue UFS has with MAPL/GOCART (see https://github.com/GEOS-ESM/MAPL/issues/2569)
  - Needed for Baselibs builds of MAPL 2.44 and higher as we now move to use `ESMF::ESMF` as the target
  - Will be added to `FindESMF.cmake` in a future release of ESMF, so we only add the alias if it doesn't exist

### Changed

- Update CI to v2 orb

## [3.38.0] - 2024-01-19

### Added

- Add `FindESMF.cmake` for use with Spack builds of GEOSgcm
- Added support for Hygon processors with Intel Fortran

## [3.37.0] - 2024-01-09

### Changed

- Fixes for `ifx` compiler
  - Set `nouninit` for check flags when building with Debug build type
  - Remove some debug flags that don't exist with `ifx`
  - Remove `-init=snan` as that causes compiler faults with some MAPL files
- For NAG, turn off setting of `ESMF_HAS_ACHAR_BUG` CMake option as it seems
  no longer needed

### Deprecated

- The `ESMF_HAS_ACHAR_BUG` CMake option is deprecated and will be removed in a future release