### PR TITLE
Disable Catchment-CN4.5 land model choice in GEOSldas

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -48,6 +48,6 @@ MAPL:
 GEOSgcm_GridComp:
   local: ./src/Components/GEOSldas_GridComp/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  branch: develop
+  branch: feature/jkolassa_disable_cn45
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse
   develop: develop

--- a/src/Applications/LDAS_App/GEOSldas_LDAS.rc
+++ b/src/Applications/LDAS_App/GEOSldas_LDAS.rc
@@ -33,7 +33,6 @@ CATCHMENT_SPINUP: 0
 #
 #    1 : Catchment model   (default)
 #    2 : CatchmentCN-CLM4.0
-#    3 : CatchmentCN-CLM4.5
 #
 LSM_CHOICE: 1
 

--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -340,8 +340,9 @@ class LDASsetup:
             self.catch = 'catch'
         if  int(self.rqdExeInp['LSM_CHOICE']) == 2 :
             self.catch = 'catchcnclm40'
-        if  int(self.rqdExeInp['LSM_CHOICE']) == 3 : 
-            self.catch = 'catchcnclm45'
+
+        assert int(self.rqdExeInp['LSM_CHOICE']) <= 2, "\nLSM_CHOICE=3 (Catchment-CN4.5) is no longer supported. Please set LSM_CHOICE to 1 (Catchment) or 2 (Catchment-CN4.0)"
+
         if 'POSTPROC_HIST' not in self.rqdExeInp:
             self.rqdExeInp['POSTPROC_HIST'] = 0
 


### PR DESCRIPTION
This PR disables the option of running the Catchment-CN4.5 land model (LSM_CHOICE=3) for GEOSldas. The experiment configuration file (exeinp) no longer includes Catchment-CN4.5 or its associated parameter set as an option. When a user runs ldas_setup with LSM_CHOICE=3, they will get the following error message:

_LSM_CHOICE=3 (Catchment-CN4.5) is no longer supported. Please set LSM_CHOICE to 1 (Catchment) or 2 (Catchment-CN4.0_

This PR is connected to a PR in the GEOSgcm_GridComp repository that removes the CN_CLM45 parameter set from GEOS_SurfaceGridComp.rc (so it is no longer listed in the exeinp file).

This PR is zero-diff for all model configurations that do not use Catchment-CN4.5.

**Notes:**

- In its current form, this PR only _disables_ the Catchment-CN4.5 model option. Removal of the Catchment-CN4.5 source code, references to LSM_CHOICE=3 in other parts of the code, and updates to the history routines will be addressed in a future PR. @gmao-rreichle , please let me know if you would like any of the above changes to be included in this PR.
- This PR only disables the Catchment-CN4.5 land model option for offline simulations. Equivalent changes to the gcm_setup are needed to also disable this land model option for coupled model simulations.

cc: @biljanaorescanin , @weiyuan-jiang