### PR TITLE
support reading corrected precipitation from aggregated daily netcdf files

### DIFF
--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -3696,7 +3696,7 @@ contains
           if ( (use_prec_corr) .and. (GEOSgcm_defs(GEOSgcm_var,1)(1:4)=='PREC') ) then
              
              call get_GEOS_corr_prec_filename(fname_full,file_exists,date_time_tmp,        &
-                  prec_path_tmp, met_tag_tmp, GEOSgcm_defs(GEOSgcm_var,:), precip_corr_file_ext,daily_precipcorr_files )
+                  prec_path_tmp, met_tag_tmp, GEOSgcm_defs(GEOSgcm_var,:), precip_corr_file_ext, daily_precipcorr_files)
 
              single_time_in_file = .not. daily_precipcorr_files  ! corr precip files are always hourly (incl. MERRA-2)
 
@@ -5622,7 +5622,7 @@ contains
   ! ****************************************************************
 
   subroutine get_GEOS_corr_prec_filename(fname_full,file_exists, date_time, met_path, met_tag, &
-       GEOSgcm_defs, file_ext,daily_files )
+       GEOSgcm_defs, file_ext, daily_files)
     
     implicit none
     character(*),                 intent(inout) :: fname_full
@@ -5642,7 +5642,7 @@ contains
     character(  4) :: YYYY,  HHMM
     character(  2) :: MM,    DD
 
-    integer        :: tmpind, tmpindend,is
+    integer        :: tmpind, tmpindend
 
     character(len=*), parameter :: Iam = 'get_GEOS_corr_prec_filename'
 
@@ -5661,19 +5661,19 @@ contains
        !  (as of 7 May 2020, no V02 or higher was issued for GEOS FP "lfo" products 
        !   going back to Jun 2013)
 
-       fname = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
+       fname     = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
             YYYY // MM // DD // '_' // trim(HHMM) // '.V01.' // trim(file_ext)
     
        fname_tmp = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
-            YYYY // MM // DD // '.V01.' // trim(file_ext)
+            YYYY // MM // DD //                      '.V01.' // trim(file_ext)
    
     else
        
-       fname = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
+       fname     = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
             YYYY // MM // DD // '_' // trim(HHMM) // 'z.'    // trim(file_ext)
       
        fname_tmp = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
-            YYYY // MM // DD // '.'    // trim(file_ext)
+            YYYY // MM // DD //                       '.'    // trim(file_ext)
  
     end if
 
@@ -5705,8 +5705,9 @@ contains
 
     if (file_exists) then
         daily_files = .true.
-        return
-    endif                            ! done
+        return                                         ! done
+    endif                            
+
     fname_full_tmp2 = trim(fname_full)                 ! remember for error log below
 
     ! third try: *without* "/Mmm" (month) dir 

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -5754,6 +5754,7 @@ contains
           print '(400A)',  trim(Iam) // ': Could not find any of the following files:'
           print '(400A)',  trim(fname_full_tmp1)
           print '(400A)',  trim(fname_full_tmp2)
+          print '(400A)',  trim(fname_full_tmp3)
           print '(400A)',  trim(fname_full)
        endif
     endif

--- a/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
+++ b/src/Components/GEOSldas_GridComp/GEOSmetforce_GridComp/LDAS_Forcing.F90
@@ -5663,12 +5663,18 @@ contains
 
        fname = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
             YYYY // MM // DD // '_' // trim(HHMM) // '.V01.' // trim(file_ext)
-       
+    
+       fname_tmp = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
+            YYYY // MM // DD // '.V01.' // trim(file_ext)
+   
     else
        
        fname = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
             YYYY // MM // DD // '_' // trim(HHMM) // 'z.'    // trim(file_ext)
-       
+      
+       fname_tmp = trim(met_tag) // '.' // trim(GEOSgcm_defs(3)) // '_corr.' //         &
+            YYYY // MM // DD // '.'    // trim(file_ext)
+ 
     end if
 
     ! assemble dir name with "/Yyy" (year) dir but without "/Mmm" (month) dir
@@ -5693,8 +5699,6 @@ contains
     fname_full_tmp1 = trim(fname_full)                 ! remember for error log below
     
     ! second try: look for daily file in year/month dir 
-    is = index(fname,'z.nc')
-    fname_tmp = fname(1:is-6)//'.'//trim(file_ext)
     fname_full = trim(fdir) // 'M' // MM // '/' // trim(fname_tmp)
 
     inquire(file=fname_full, exist=file_exists)


### PR DESCRIPTION
To reduce the number of files on disk, we can aggregate the 24 hourly corrected precipitation files into 1 daily file.   The updates support reading from both hourly and daily (if no hourly file is found) files. 