### PR TITLE
Update some GitHub Actions versions

### DIFF
--- a/.github/workflows/push-to-develop.yml
+++ b/.github/workflows/push-to-develop.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run the action

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
         with:
           path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
 
       - name: Checkout mepo
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
         with:
           repository: GEOS-ESM/mepo
           path: mepo


### PR DESCRIPTION
Was doing some comparing and found that GEOSldas was still using `checkout@v3` in some GitHub Actions. The latest version is `v4` so we move to use that.

If the CI works, it's good code, if it doesn't it's bad code. GEOSldas itself doesn't care. 

Note: This is not a huge rush to get in.