### PR TITLE
create IMS.rc or JMS.rc directly on run_dir

### DIFF
--- a/src/Applications/LDAS_App/ldas_setup
+++ b/src/Applications/LDAS_App/ldas_setup
@@ -1043,24 +1043,16 @@ class LDASsetup:
 
         # get optimzed NX and IMS
         optimized_distribution_file = tempfile.NamedTemporaryFile(delete=False)
-        tmp_path = os.path.dirname(optimized_distribution_file.name )
-        print("tmp_path:"+tmp_path)
         print  ("Optimizing... decomposition of processes.... \n")
-        cmd = self.bindir + '/preprocess_ldas.x optimize '+ self.inpdir+'/tile.data '+ str(self.rqdRmInp['ntasks_model']) + ' ' + optimized_distribution_file.name
+        cmd = self.bindir + '/preprocess_ldas.x optimize '+ self.inpdir+'/tile.data '+ str(self.rqdRmInp['ntasks_model']) + ' ' + optimized_distribution_file.name + ' ' + self.rundir
         print ("cmd:   " + cmd)
+        print ("IMS.rc or JMS.rc would be generated on " + self.rundir)
         sp.call(shlex.split(cmd))
         optinxny=self._parseInputFile(optimized_distribution_file.name)
         if (int(optinxny['NX']) == 1):
             if int(optinxny['NY']) != int(self.rqdRmInp['ntasks_model']):
                 self.rqdRmInp['ntasks_model']=optinxny['NY']
                 print ('adjust ntasks_model %d for cubed-sphere grid' % int(self.rqdRmInp['ntasks_model']))
-
-        if os.path.isfile( tmp_path+'/IMS.rc') :
-            shutil.move(tmp_path+'/IMS.rc', self.rundir+'/')
-            print("move file: " + tmp_path+'/IMS.rc')
-        if os.path.isfile( tmp_path+'/JMS.rc') :
-            shutil.move(tmp_path+'/JMS.rc', self.rundir+'/')
-            print("move file: " + tmp_path+'/JMS.rc')
 
 
         #os.remove(optimized_distribution_file.name)

--- a/src/Applications/LDAS_App/preprocess_ldas.F90
+++ b/src/Applications/LDAS_App/preprocess_ldas.F90
@@ -129,7 +129,7 @@ program main
   else if (trim(option) == "optimize") then
      
       
-     call optimize_latlon(arg1,arg2, arg3)
+     call optimize_latlon(arg1,arg2, arg3, arg4)
      
   else
      

--- a/src/Applications/LDAS_App/preprocess_ldas_routines.F90
+++ b/src/Applications/LDAS_App/preprocess_ldas_routines.F90
@@ -2042,13 +2042,14 @@ contains
   ! NY:     N_proc                1
   !         JMS.rc                IMS.rc
   
-  subroutine optimize_latlon(fname_tilefile, N_proc_string, optimized_file)
+  subroutine optimize_latlon(fname_tilefile, N_proc_string, optimized_file, run_dir)
     
     implicit none
     
     character(*), intent(in) :: fname_tilefile  ! file name (with path) of tile file (*.til)
     character(*), intent(in) :: N_proc_string   ! *string* w/ no. of processors (or tasks), excl. OSERVER tasks
     character(*), intent(in) :: optimized_file  
+    character(*), intent(in) :: run_dir  
         
     ! local variables
     integer :: N_proc
@@ -2287,8 +2288,7 @@ contains
        write(10,'(A)')    "GEOSldas.JMS_FILE:    JMS.rc"
        close(10)
        
-       n = index(optimized_file, '/', back=.true.)
-       JMS_file = optimized_file(1:n)//"JMS.rc"
+       JMS_file = trim(run_dir)//"/JMS.rc"
        open(10,file=JMS_file ,action='write')
        write(10,'(I5,I5)') N_proc, maxval(face)
        do n=1,N_proc
@@ -2483,8 +2483,7 @@ contains
        write(10,'(A)')    "GEOSldas.IMS_FILE:   IMS.rc"
        close(10)
        
-       n = index(optimized_file, '/', back=.True.)
-       IMS_file = optimized_file(1:n)//"IMS.rc"
+       IMS_file = trim(run_dir)//"/IMS.rc"
        open(10,file=IMS_file,action='write')
        write(10,'(I5)') N_proc
        do n=1,N_proc


### PR DESCRIPTION
The present PR is a continuation of #733.  
It is not safe when multi ldas_setup run at the same time and using the same IMS.rc or JMS.rc.  This PR creates the files on the run directory.