### PR TITLE
Move GEOSgcm_GridComp under Components in GEOSldas

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -49,7 +49,7 @@ MAPL:
 GEOSldas_GridComp:
   local: ./src/Components/@GEOSldas_GridComp
   remote: ../GEOSldas_GridComp.git
-  branch: develop
+  branch: feature/mathomp4/move-gcmgc-ldas
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -53,7 +53,7 @@ GEOSldas_GridComp:
   develop: develop
 
 GEOSgcm_GridComp:
-  local: ./src/Components/@GEOSldas_GridComp/@GEOSgcm_GridComp
+  local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
   branch: develop
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse

--- a/components.yaml
+++ b/components.yaml
@@ -49,7 +49,7 @@ MAPL:
 GEOSldas_GridComp:
   local: ./src/Components/@GEOSldas_GridComp
   remote: ../GEOSldas_GridComp.git
-  branch: feature/mathomp4/move-gcmgc-ldas
+  branch: develop
   develop: develop
 
 GEOSgcm_GridComp:

--- a/src/Components/.gitignore
+++ b/src/Components/.gitignore
@@ -1,3 +1,6 @@
 /@GEOSldas_GridComp
 /GEOSldas_GridComp
 /GEOSldas_GridComp@
+/@GEOSgcm_GridComp
+/GEOSgcm_GridComp
+/GEOSgcm_GridComp@

--- a/src/Components/CMakeLists.txt
+++ b/src/Components/CMakeLists.txt
@@ -1,1 +1,2 @@
 esma_add_subdirectory (GEOSldas_GridComp)
+esma_add_subdirectory (GEOSgcm_GridComp)


### PR DESCRIPTION
Currently, GEOSgcm_GridComp is cloned via mepo under GEOSldas_GridComp (which echoes how it was in in GEOSldas v17 and older). This PR moves GEOSgcm_GridComp under Components in GEOSldas. This makes its location consistent with GEOSgcm and GEOSadas.

Note that this PR requires a corresponding change in the GEOSldas_GridComp repo:

https://github.com/GEOS-ESM/GEOSldas_GridComp/pull/27

---

Also, in this PR I've update `components.yaml` to point to the corresponding branch in GEOSldas_GridComp. This of course moves to `develop` and then a tag in the usual way.