### PR TITLE
Update components.yaml to match GEOSgcm main as of 2024-Oct-21

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -5,19 +5,19 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.29.0
+  tag: v4.29.1
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.48.0
+  tag: v3.52.0
   develop: develop
 
 ecbuild:
   local: ./@cmake/@ecbuild
   remote: ../ecbuild.git
-  tag: geos/v1.3.0
+  tag: geos/v1.4.0
 
 NCEP_Shared:
   local: ./src/Shared/@NCEP_Shared
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.9.8
+  tag: v1.9.9
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
@@ -40,16 +40,18 @@ GEOS_Util:
   sparse: ./config/GEOS_Util.sparse
   develop: main
 
+# When updating the MAPL version, also update the MAPL version in the
+# CMakeLists.txt file for non-Baselibs builds
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.47.1
+  tag: v2.50.1
   develop: develop
 
 GEOSldas_GridComp:
   local: ./src/Components/@GEOSldas_GridComp
   remote: ../GEOSldas_GridComp.git
-  branch: develop
+  branch: feature/mathomp4/add-impi-support-ldas
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
As presaged by #780, GEOSgcm v11 has moved to use Intel MPI on SLES15 at NCCS for Intel Fortran. This PR grabs that along with some other updates. These updates go along with the `feature/mathomp4/add-impi-support-ldas` branch in GEOSldas_GridComp (see https://github.com/GEOS-ESM/GEOSldas_GridComp/pull/57)

Hopefully @biljanaorescanin can do a full test of this (Intel and GNU) and make sure all is well. All our testing on the GEOSgcm shows it as zero-diff.

---

Changes in more detail:

- ESMA_env v4.29.0 → v4.29.1
  - Update to Intel MPI 2021.13
- ESMA_cmake v3.48.0 → v3.52.0
  - Various updates including changes to use MAPL-as-library with Spack, fixes for MAPL3, NAG, and Jemalloc
- ecbuild geos/v1.3.0 → geos/v1.4.0
  - Fix for using GCC on macOS with Xcode 16
- GMAO_Shared v1.9.8 → v1.9.9
  - Fixes for gcc 14 and other minor CMake
- MAPL v2.47.1 → v2.50.1
  - Quite a few updates and fixes (see [CHANGELOG.md](https://github.com/GEOS-ESM/MAPL/compare/v2.47.1...v2.50.1#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)) but I don't think any have direct effect on LDAS. If anything probably fixes bugs that could possibly be encountered
- GEOSldas `feature/mathomp4/add-impi-support-ldas` (see https://github.com/GEOS-ESM/GEOSldas_GridComp/pull/57)
  - Adds support for Intel MPI in the run scripts