### PR TITLE
Update env, cmake, GEOS_Util and MAPL releases in components.yaml & update README.md after decommissioning of SLES12 at NCCS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.17.0
-#bcs_version: &bcs_version v11.4.0
+#baselibs_version: &baselibs_version v7.32.0
+#bcs_version: &bcs_version v11.6.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@4
 
 workflows:
   build-test:

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -14,16 +14,20 @@ jobs:
         with:
           path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
 
-      - name: Checkout mepo
-        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          repository: GEOS-ESM/mepo
-          path: mepo
+          python-version: '3.11'
+
+      - name: Pip install mepo
+        run: |
+          python -m pip install --upgrade pip
+          pip install mepo
 
       - name: Run mepo
         run : |
           cd ${GITHUB_WORKSPACE}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
-          ${GITHUB_WORKSPACE}/mepo/mepo clone
+          mepo clone
 
       - name: Create tarball
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.24)
 cmake_policy (SET CMP0053 NEW)
 cmake_policy (SET CMP0054 NEW)
 
@@ -33,7 +33,54 @@ foreach (dir cmake @cmake cmake@)
     set (ESMA_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}" CACHE PATH "Path to ESMA_cmake code")
   endif ()
 endforeach ()
+
+# We need to find MPI before we go into esma
+# for the MPI stack detection to work
+set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+find_package(MPI)
+
 include (esma)
+
+# Add CMake for when not using Baselibs
+if (NOT Baselibs_FOUND)
+
+  find_package(NetCDF REQUIRED C Fortran)
+  add_definitions(-DHAS_NETCDF4)
+  add_definitions(-DHAS_NETCDF3)
+  add_definitions(-DNETCDF_NEED_NF_MPIIO)
+  add_definitions(-DHAS_NETCDF3)
+
+  find_package(HDF5 REQUIRED)
+  if(HDF5_IS_PARALLEL)
+     add_definitions(-DH5_HAVE_PARALLEL)
+  endif()
+
+  if (NOT TARGET ESMF::ESMF)
+    find_package(ESMF 8.6.1 MODULE REQUIRED)
+    target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
+
+    # GEOS uses lowercase target due to historical reasons but
+    # the latest FindESMF.cmake file from ESMF produces an ESMF::ESMF target.
+    if (NOT TARGET esmf)
+      add_library(esmf ALIAS ESMF::ESMF)
+    endif ()
+    if (NOT TARGET ESMF)
+      add_library(ESMF ALIAS ESMF::ESMF)
+    endif ()
+  endif ()
+
+  find_package(GFTL_SHARED REQUIRED)
+
+  find_package(ZLIB REQUIRED)
+  # Another issue with historical reasons, old/wrong zlib target used in GEOS
+  add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
+
+  find_package(MAPL 2.54 QUIET)
+  if (MAPL_FOUND)
+    message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
+  endif ()
+
+endif ()
 
 ecbuild_declare_project()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,22 +1,14 @@
 ﻿{
-  "version": 3,
+  "version": 7,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21,
+    "minor": 27,
     "patch": 0
   },
+  "include": [
+    "presets/CMake$penv{CMAKE_PRESET_NAME}Presets.json"
+  ],
   "configurePresets": [
-    {
-      "name": "base-configure",
-      "hidden": true,
-      "displayName": "Base Configure Settings",
-      "description": "Sets build and install directories",
-      "binaryDir": "${sourceDir}/build-${presetName}",
-      "cacheVariables": {
-        "BASEDIR": "$env{BASEDIR}",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}"
-      }
-    },
     {
       "name": "base-gnu",
       "hidden": true,

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ git clone -b v17.9.1 --single-branch git@github.com:GEOS-ESM/GEOSldas.git
 To build the model in a single step, do the following from a head node:
 ```
 cd ./GEOSldas
-./parallel_build.csh -mil
+./parallel_build.csh
 ```
 This checks out all the external repositories of the model (albeit only on the first run, [see subsection on mepo below](#mepo)!) and then builds and installs the model. 
 
 The resulting model build is found in `build-SLES15/`, and the installation is found in `install-SLES15/`, with setup scripts like `ldas_setup` in `install-SLES15/bin`.
 
-To obtain a build that is suitable for debugging, use `./parallel_build.csh -debug -mil`, which builds in `build-Debug-SLES15/` and installs in `install-Debug-SLES15/`.  There is also an option for aggressive  optimization.  For details, see the [GEOSldas Wiki](https://github.com/GEOS-ESM/GEOSldas/wiki).
+To obtain a build that is suitable for debugging, use `./parallel_build.csh -debug`, which builds in `build-Debug/` and installs in `install-Debug/`.  There is also an option for aggressive  optimization.  For details, see the [GEOSldas Wiki](https://github.com/GEOS-ESM/GEOSldas/wiki).
 
 Instructions for building the model in multiple steps are provided below.
 
@@ -60,9 +60,7 @@ Instructions for building the model in multiple steps are provided below.
 ## How to Set Up (Configure) and Run GEOSldas
 
 
-a) To run GEOSldas on Milan nodes (SLES15), start with `ssh discover-mil`.
-
-b) Set up the job as follows:
+Set up the job as follows:
 
 ```
 cd (build_path)/GEOSldas/install-SLES15/bin

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Instructions for building the model in multiple steps are provided below.
 Set up the job as follows:
 
 ```
-cd (build_path)/GEOSldas/install-SLES15/bin
+cd (build_path)/GEOSldas/install-Release/bin
 source g5_modules                                              [for bash or zsh: source g5_modules.[z]sh]
 ./ldas_setup setup [-v]  (exp_path)  ("exe"_input_filename)  ("bat"_input_filename)
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ For science runs, you can also obtain a specific tag or branch _only_ (as oppose
 ```
 git clone -b v17.9.1 --single-branch git@github.com:GEOS-ESM/GEOSldas.git
 ```
-
+Helpful tip: You can speed up this step by applying the following, one-time `mepo` configuration change:
+```
+mepo config set clone.partial blobless
+```
+With this configuration change, the size of the initial clone will be reduced, and additional blobs are fetched later when needed.
 
 ### Step 3: Build the Model
 
@@ -49,7 +53,7 @@ cd ./GEOSldas
 ```
 This checks out all the external repositories of the model (albeit only on the first run, [see subsection on mepo below](#mepo)!) and then builds and installs the model. 
 
-The resulting model build is found in `build-SLES15/`, and the installation is found in `install-SLES15/`, with setup scripts like `ldas_setup` in `install-SLES15/bin`.
+The resulting model build is found in `build-Release/`, and the installation is found in `install-Release/`, with setup scripts like `ldas_setup` in `install-Release/bin/`.
 
 To obtain a build that is suitable for debugging, use `./parallel_build.csh -debug`, which builds in `build-Debug/` and installs in `install-Debug/`.  There is also an option for aggressive  optimization.  For details, see the [GEOSldas Wiki](https://github.com/GEOS-ESM/GEOSldas/wiki).
 
@@ -64,7 +68,7 @@ Set up the job as follows:
 
 ```
 cd (build_path)/GEOSldas/install-SLES15/bin
-source g5_modules                        [for bash or zsh: source g5_modules.[z]sh]
+source g5_modules                                              [for bash or zsh: source g5_modules.[z]sh]
 ./ldas_setup setup [-v]  (exp_path)  ("exe"_input_filename)  ("bat"_input_filename)
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cd ./GEOSldas
 ```
 This checks out all the external repositories of the model (albeit only on the first run, [see subsection on mepo below](#mepo)!) and then builds and installs the model. 
 
-The resulting model build is found in `build-Release/`, and the installation is found in `install-Release/`, with setup scripts like `ldas_setup` in `install-Release/bin/`.
+The resulting model build is found in `build/`, and the installation is found in `install/`, with setup scripts like `ldas_setup` in `install/bin/`.
 
 To obtain a build that is suitable for debugging, use `./parallel_build.csh -debug`, which builds in `build-Debug/` and installs in `install-Debug/`.  There is also an option for aggressive  optimization.  For details, see the [GEOSldas Wiki](https://github.com/GEOS-ESM/GEOSldas/wiki).
 
@@ -67,7 +67,7 @@ Instructions for building the model in multiple steps are provided below.
 Set up the job as follows:
 
 ```
-cd (build_path)/GEOSldas/install-Release/bin
+cd (build_path)/GEOSldas/install/bin
 source g5_modules                                              [for bash or zsh: source g5_modules.[z]sh]
 ./ldas_setup setup [-v]  (exp_path)  ("exe"_input_filename)  ("bat"_input_filename)
 ```

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.29.1
+  tag: v4.35.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.52.0
+  tag: v3.56.0
   develop: develop
 
 ecbuild:
@@ -36,7 +36,7 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.1.3
+  branch: feature/wjiang/cleanup_helsurface
   sparse: ./config/GEOS_Util.sparse
   develop: main
 
@@ -45,7 +45,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.50.1
+  tag: v2.54.1
   develop: develop
 
 GEOSldas_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  branch: v1.9.9
+  tag: v1.9.9
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  branch: feature/wjiang/cleanup_helsurface
+  branch: v1.9.9
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 

--- a/components.yaml
+++ b/components.yaml
@@ -29,14 +29,14 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.9.9
+  branch: feature/wjiang/cleanup_helsurface
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  branch: feature/wjiang/cleanup_helsurface
+  tag: v2.1.6
   sparse: ./config/GEOS_Util.sparse
   develop: main
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.35.0
+  tag: v4.36.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.56.0
+  tag: v3.57.0
   develop: develop
 
 ecbuild:
@@ -45,7 +45,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.54.1
+  tag: v2.54.2
   develop: develop
 
 GEOSldas_GridComp:

--- a/parallel_build.csh
+++ b/parallel_build.csh
@@ -41,8 +41,7 @@ if (! -d ${ESMADIR}/@env) then
       echo " Please run from a head node"
       exit 1
    else
-      echo "Running mepo initialization"
-      mepo init
+      echo "Running mepo clone"
       mepo clone
    endif
 endif

--- a/presets/CMakeDefaultPresets.json
+++ b/presets/CMakeDefaultPresets.json
@@ -1,0 +1,13 @@
+﻿{
+  "configurePresets": [
+    {
+      "name": "base-configure",
+      "hidden": true,
+      "displayName": "Base Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "installDir": "${sourceDir}/install-${presetName}"
+    }
+  ],
+  "version": 7
+}

--- a/presets/CMakeNCCSPresets.json
+++ b/presets/CMakeNCCSPresets.json
@@ -1,0 +1,13 @@
+﻿{
+  "configurePresets": [
+    {
+      "name": "base-configure",
+      "hidden": true,
+      "displayName": "Base Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "$penv{CMAKE_BUILD_LOCATION}/${sourceDirName}/build-${presetName}",
+      "installDir": "$penv{CMAKE_INSTALL_LOCATION}/${sourceDirName}/install-${presetName}"
+    }
+  ],
+  "version": 7
+}


### PR DESCRIPTION
This **non-0-diff** PR updates the `components.yaml` to approximately match that of GEOSgcm `main` as of 2025-Mar-19.  

```
env:       v4.29.1 --> v4.36.0
cmake:     v3.52.0 --> v3.57.0
GEOS_Util: v2.1.3  --> v2.1.6
MAPL:      v2.50.1 --> v2.54.2
```

The **non-0-diff** changes are within **"roundoff,"** and are caused by the newer compiler/baselibs version.  Intel tests with standard optimization are **0-diff when bit shaving is _not_ used**. 

Note that the ESMA_env, ESMA_cmake, and MAPL versions are slightly newer than those of GEOSgcm `main`, but per the respective release notes this should be 0-diff w.r.t. what is in GEOSgcm `main` (but **not** 0-diff w.r.t. what is on GEOSldas `develop` before this PR!).

The PR also updates README.md to reflect that SLES15 is now the only O/S on the NCCS Discover platform.

Earlier versions of this PR also included the helfsurface() optimization of https://github.com/GEOS-ESM/GMAO_Shared/pull/348, which requires a newer Intel compiler but should be zero-diff (which is why it will be done in a separate PR).
