### PR TITLE
Add BUILD_INFO.rc file, update parallel_build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.32.0
+#baselibs_version: &baselibs_version v7.33.0
 #bcs_version: &bcs_version v11.6.0
 
 orbs:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,7 +20,7 @@ jobs:
     name: gfortran / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v7.32.0-openmpi_5.0.5-gcc_14.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v7.33.0-openmpi_5.0.5-gcc_14.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +49,7 @@ jobs:
     name: ifort / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v7.32.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.13-ifort_2021.13
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +77,7 @@ jobs:
   #   name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }} #
   #   runs-on: ubuntu-latest                                                     #
   #   container:                                                                 #
-  #     image: gmao/ubuntu24-geos-env:v7.32.0-intelmpi_2021.14-ifx_2025.0        #
+  #     image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.14-ifx_2025.0        #
   #   strategy:                                                                  #
   #     fail-fast: false                                                         #
   #     matrix:                                                                  #

--- a/BUILD_INFO.rc.in
+++ b/BUILD_INFO.rc.in
@@ -1,0 +1,45 @@
+== Build Configuration ==
+Build Type: @CMAKE_BUILD_TYPE@
+
+== System ==
+System Name: @CMAKE_SYSTEM_NAME@
+System Version: @CMAKE_SYSTEM_VERSION@
+Host System: @CMAKE_HOST_SYSTEM@
+Processor Description: @proc_description@
+
+== CMake ==
+CMake Version Used for Build: @CMAKE_VERSION@
+CMake Required Version: @CMAKE_MINIMUM_REQUIRED_VERSION@
+
+== Git ==
+Git Version: @GIT_VERSION_STRING@
+
+== Modules ==
+@ENVIRONMENT_MODULES@
+
+== Basedir ==
+BASEDIR: @BASEDIR_WITHOUT_ARCH@
+
+== Compilers ==
+C Compiler: @CMAKE_C_COMPILER@ (ID: @CMAKE_C_COMPILER_ID@ @CMAKE_C_COMPILER_VERSION@)
+C++ Compiler: @CMAKE_CXX_COMPILER@ (ID: @CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@)
+Fortran Compiler: @CMAKE_Fortran_COMPILER@ (ID: @CMAKE_Fortran_COMPILER_ID@ @CMAKE_Fortran_COMPILER_VERSION@)
+
+== MPI ==
+MPI C Compiler: @MPI_C_COMPILER@
+MPI C++ Compiler: @MPI_CXX_COMPILER@
+MPI Fortran Compiler: @MPI_Fortran_COMPILER@
+MPI Version: @MPI_VERSION@
+MPI Libraries: @MPI_LIBRARIES@
+MPI Stack: @MPI_STACK@
+MPI Stack Version: @MPI_STACK_VERSION@
+
+== BLAS ==
+BLAS_LIBRARIES: @BLAS_LIBRARIES@
+
+== LAPACK ==
+LAPACK_LIBRARIES: @LAPACK_LIBRARIES@
+
+== ESMF ==
+ESMF_VERSION: @ESMF_VERSION@
+ESMFMKFILE: @ESMFMKFILE@

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ esma_add_subdirectory (${env_dir})
 # Recursively build source tree
 add_subdirectory (src)
 
+configure_file(BUILD_INFO.rc.in BUILD_INFO.rc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/BUILD_INFO.rc DESTINATION etc)
+
 # https://www.scivision.dev/cmake-auto-gitignore-build-dir/
 # --- auto-ignore build directory
 if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)

--- a/parallel_build.csh
+++ b/parallel_build.csh
@@ -34,7 +34,9 @@ set origargv = "$argv"
 # end                         #
 ###############################
 
-if (! -d ${ESMADIR}/@env) then
+if (-d ${ESMADIR}/@env || -d ${ESMADIR}/env@ || -d ${ESMADIR}/env) then
+   mepo status
+else
    if ($?PBS_JOBID || $?SLURM_JOBID) then
       echo " mepo clone must be run!"
       echo " This requires internet access but you are on a compute node"
@@ -42,7 +44,8 @@ if (! -d ${ESMADIR}/@env) then
       exit 1
    else
       echo "Running mepo clone"
-      mepo clone
+      mepo clone --partial blobless
+      mepo status
    endif
 endif
 


### PR DESCRIPTION
This PR does a few minor things:

1. Adds a new `BUILD_INFO.rc` file (see below)
2. Updates `parallel_build.csh` to resemble the one in GEOSgcm (mainly adding a call to `mepo status` and using blobless clones)
3. Minor tweaks to CI

---

The new `BUILD_INFO.rc` file will be put in `install/etc` and look like:

```
== Build Configuration ==
Build Type: Release

== System ==
System Name: Linux
System Version: 5.14.21-150400.24.100-default
Host System: Linux-5.14.21-150400.24.100-default
Processor Description: 48 core Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz

== CMake ==
CMake Version Used for Build: 3.30.3
CMake Required Version: 3.24

== Git ==
Git Version: 2.49.0

== Modules ==
fast-mkl-amd/1.0;python/GEOSpyD/24.11.3-0/3.12;git/2.49.0;cmake/3.30.3;other/mepo/2.3.2;other/tig/2.5.8;ImageMagick/7.1.1-15;git-lfs/3.4.0;other/gh;other/tree/2.1.0;other/ninja/1.12.0;GEOSenv;comp/gcc/12.3.0;comp/intel/2024.2.0;mpi/impi/2021.13

== Basedir ==
BASEDIR: /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.33.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0

== Compilers ==
C Compiler: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/icx (ID: IntelLLVM 2024.2.0)
C++ Compiler: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/icpx (ID: IntelLLVM 2024.2.0)
Fortran Compiler: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/ifort (ID: Intel 2021.0.0.20240602)

== MPI ==
MPI C Compiler: /usr/local/intel/oneapi/2024/mpi/2021.13/bin/mpiicx
MPI C++ Compiler: /usr/local/intel/oneapi/2024/mpi/2021.13/bin/mpiicpx
MPI Fortran Compiler: /usr/local/intel/oneapi/2024/mpi/2021.13/bin/mpiifort
MPI Version:
MPI Libraries: /gpfsm/dulocal15/sles15/intel/oneapi/2024/mpi/2021.13/lib/libmpicxx.so;/gpfsm/dulocal15/sles15/intel/oneapi/2024/mpi/2021.13/lib/libmpifort.so;/gpfsm/dulocal15/sles15/intel/oneapi/2024/mpi/2021.13/lib/libmpi.so;/usr/lib64/libdl.so;/usr/lib64/librt.so;/usr/lib64/libpthread.so
MPI Stack: intelmpi
MPI Stack Version: 2021.13

== BLAS ==
BLAS_LIBRARIES: /usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_intel_lp64.so;/usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_sequential.so;/usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_core.so;-pthread;-lm;-ldl

== LAPACK ==
LAPACK_LIBRARIES: /usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_intel_lp64.so;/usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_sequential.so;/usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_core.so;-pthread;-lm;-ldl;-pthread;-lm;-ldl

== ESMF ==
ESMF_VERSION: 8.8.1
ESMFMKFILE: /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.33.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0/Linux/lib/esmf.mk
```

It's just a place to put some info that CMake knows about in a single file. To help a bit.