### PR TITLE
Update GEOS_Util version to v2.1.9 (components.yaml)

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.1.8
+  tag: v2.1.9
   sparse: ./config/GEOS_Util.sparse
   develop: main
 


### PR DESCRIPTION
v2.1.9 fixes issue with saltwater in remap_lake_landice_salt (https://github.com/GEOS-ESM/GEOS_Util/pull/144)

Skipping 0-diff tests because GEOSldas tests are insensitive to this change.
