### PR TITLE
WIP: Testing 8.17 AEC Baselibs

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -57,7 +57,7 @@ MAPL:
 GEOSldas_GridComp:
   local: ./src/Components/@GEOSldas_GridComp
   remote: ../GEOSldas_GridComp.git
-  branch: develop
+  branch: testing-8.17-AEC-baselibs
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.62.1
+  branch: feature/v3-add-aec-support
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.38.0
+  branch: testing-8.17-AEC-baselibs
   develop: main
 
 cmake:


### PR DESCRIPTION
I am testing a new Baselibs that moves away from using szip which has long been considered ancient and recently the HDF Group just *removed* the page about it on their site. Instead, it moves to libaec which is the "successor" of szip and can be used the same, just with some link-time changes.

The only reason I'm concerned with the LDAS is that it might be one of the places we still use szip. I mean, GEOSldas assimilates HDF4 files and maybe those are szip compressed? I dunno.

So, I'm hoping someone can run the Intel tests, especially assim, with this PR. Just to see.

I pinged @weiyuan-jiang on Teams to ask if he could run it. I don't want to make a mistake and screw up my nightly tests somehow.