### PR TITLE
Update components to match GEOSgcm v11 as of 2025-Sep-19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.33.0
+#baselibs_version: &baselibs_version v8.18.0
 #bcs_version: &bcs_version v11.6.0
 
 orbs:

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,7 +20,7 @@ jobs:
     name: gfortran / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v7.33.0-openmpi_5.0.5-gcc_14.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v8.18.0-openmpi_5.0.5-gcc_14.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
       OMPI_MCA_btl_vader_single_copy_mechanism: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           filter: blob:none
@@ -49,7 +49,7 @@ jobs:
     name: ifort / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.18.0-intelmpi_2021.13-ifort_2021.13
     strategy:
       fail-fast: false
       matrix:
@@ -57,7 +57,7 @@ jobs:
         cmake-generator: [Unix Makefiles]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           filter: blob:none
@@ -77,7 +77,7 @@ jobs:
   #   name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }} #
   #   runs-on: ubuntu-latest                                                     #
   #   container:                                                                 #
-  #     image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.14-ifx_2025.0        #
+  #     image: gmao/ubuntu24-geos-env:v8.18.0-intelmpi_2021.15-ifx_2025.1        #
   #   strategy:                                                                  #
   #     fail-fast: false                                                         #
   #     matrix:                                                                  #
@@ -85,7 +85,7 @@ jobs:
   #       cmake-generator: [Unix Makefiles]                                      #
   #   steps:                                                                     #
   #     - name: Checkout                                                         #
-  #       uses: actions/checkout@v4                                              #
+  #       uses: actions/checkout@v5                                              #
   #       with:                                                                  #
   #         fetch-depth: 1                                                       #
   #         filter: blob:none                                                    #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if (NOT Baselibs_FOUND)
   # Another issue with historical reasons, old/wrong zlib target used in GEOS
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
 
-  find_package(MAPL 2.57 QUIET)
+  find_package(MAPL 2.59 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.38.0
+  tag: v5.13.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.62.1
+  tag: v3.64.0
   develop: develop
 
 ecbuild:
@@ -29,14 +29,14 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v2.1.1
+  tag: v2.1.4
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.1.9
+  tag: v2.1.10
   sparse: ./config/GEOS_Util.sparse
   develop: main
 
@@ -51,7 +51,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.57.0
+  tag: v2.59.1
   develop: develop
 
 GEOSldas_GridComp:


### PR DESCRIPTION
This PR updates the components in GEOSldas to match that of GEOSgcm `main` as of 2025-Sep-19. This brings in a few things:

* ESMA_env v5.13.0
  * Update to Baselibs 8.18.0
    * ESMF 8.9.0
    * curl 8.15.0
    * NCO 5.3.4
    * CDO 2.5.3
    * nccmp 1.10.0.0
    * Removed szip, added libaec
      * Note: To use libaec correctly, users should use ESMA_cmake v3.63.0/v4.20.0 or higher
* ESMA_cmake v3.64.0
  * Support for libaec in Baselibs
* GMAO_Shared v2.1.4
  * Changes to some scripts and `esma_mpirun`
* GEOS_Util v2.1.10
  * Various updates (see https://github.com/GEOS-ESM/GEOS_Util/blob/main/CHANGELOG.md)
* MAPL 2.59.1
  * Support for ESMF v9
  * Various fixes and features

I've also updated some CI to test if all this works.

The *most* important part of this is MAPL 2.59.1. That is important because it provides support for ESMF v9. Now, MAPL2 (and thus GEOSgcm, GEOSldas, etc.) does *not* require ESMF v9 but MAPL3 does. But, having support to use ESMF v9 allows us to keep around a single set of Baselibs/ESMA_env.

Second, #835 by @biljanaorescanin trumps this in terms of GEOS_Util, but I decided to just echo GEOSgcm `main`

Third, as I know @gmao-rreichle will probably spot it, ESMA_env went from v4 to v5. Now, that difference is because ESMA_env v5 has Baselibs v8 which includes FMS (which doesn't matter to GEOSldas).

I'm going to keep this draft until it can be tested by @biljanaorescanin or others. But I wanted to get this in to see what CI does.