### PR TITLE
Update components to match or exceed GEOSgcm v11 as of 2026-Apr-07

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v8.18.0
+#baselibs_version: &baselibs_version v8.27.0
 #bcs_version: &bcs_version v11.6.0
 
 orbs:

--- a/.github/workflows/push-to-develop.yml
+++ b/.github/workflows/push-to-develop.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run the action
-        uses: devops-infra/action-pull-request@v0.5.5
+        uses: devops-infra/action-pull-request@v1.0.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: develop

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,7 +20,7 @@ jobs:
     name: gfortran / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v8.18.0-openmpi_5.0.5-gcc_14.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_14.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
       OMPI_MCA_btl_vader_single_copy_mechanism: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           filter: blob:none
@@ -49,7 +49,7 @@ jobs:
     name: ifort / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.18.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
     strategy:
       fail-fast: false
       matrix:
@@ -57,7 +57,7 @@ jobs:
         cmake-generator: [Unix Makefiles]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           filter: blob:none
@@ -77,7 +77,7 @@ jobs:
   #   name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }} #
   #   runs-on: ubuntu-latest                                                     #
   #   container:                                                                 #
-  #     image: gmao/ubuntu24-geos-env:v8.18.0-intelmpi_2021.15-ifx_2025.1        #
+  #     image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.15-ifx_2025.1        #
   #   strategy:                                                                  #
   #     fail-fast: false                                                         #
   #     matrix:                                                                  #
@@ -85,7 +85,7 @@ jobs:
   #       cmake-generator: [Unix Makefiles]                                      #
   #   steps:                                                                     #
   #     - name: Checkout                                                         #
-  #       uses: actions/checkout@v5                                              #
+  #       uses: actions/checkout@v6                                              #
   #       with:                                                                  #
   #         fetch-depth: 1                                                       #
   #         filter: blob:none                                                    #

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSldas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.13.0
+  tag: v5.21.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.64.0
+  tag: v3.75.0
   develop: develop
 
 ecbuild:
@@ -29,14 +29,14 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v2.1.4
+  tag: v2.1.6
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.1.10
+  tag: v2.1.12
   sparse: ./config/GEOS_Util.sparse
   develop: main
 
@@ -51,7 +51,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.63.1
+  tag: v2.68.0
   develop: develop
 
 GEOSldas_GridComp:


### PR DESCRIPTION
This PR updates the project components to match or exceed GEOSgcm v11 as of 2026-Apr-07. It's been a while so I thought I'd make one.

It also has some pretty minor CI updates.

## Component Updates
- ESMA_env: v5.13.0 → v5.21.0
  - Update to Baselibs 8.27.0
    - ESMF 9.0.0b10, GFE v1.23.0
  - Better support for Athena/Turin at NAS
- ESMA_cmake: v3.64.0 → v3.75.0
  - Updates for ifx and flang flags
  - Better support for Athena/Turin at NAS
  - So so many f2py hacks and workarounds and fixes and ...
- GMAO_Shared: v2.1.4 → v2.1.6
  - Better support for Athena/Turin at NAS
  - Lots of minor things
- GEOS_Util: v2.1.10 → v2.1.12
  - Plots and remapping fixes
- MAPL: v2.63.1 → v2.68.0
  - Lots of bugfixes and new features, though I'm not sure anything was LDAS focused

I'm like 99.99% sure this should be zero-diff for LDAS. 